### PR TITLE
Compute normals, tangents and UV coordinates

### DIFF
--- a/EvoEngine_Plugins/EcoSysLab/Internals/EcoSysLabResources/Shaders/Compute/DynamicStrands/Prediction/UniformParticle.comp
+++ b/EvoEngine_Plugins/EcoSysLab/Internals/EcoSysLabResources/Shaders/Compute/DynamicStrands/Prediction/UniformParticle.comp
@@ -43,6 +43,8 @@ void main(){
 
 		uniform_particles[uniform_particle_index].position_t.xyz = 
 			mix(particle0.x, particle1.x, uniform_particle.position_t.w);
-
+		uniform_particles[uniform_particle_index].tangent.xyz = normalize(particle1.x - particle0.x);
+		// need to reset normals
+		uniform_particles[uniform_particle_index].normal_deg = vec4(0.0f);
 	}
 }

--- a/EvoEngine_Plugins/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrandsRendering.mesh
+++ b/EvoEngine_Plugins/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrandsRendering.mesh
@@ -3,6 +3,7 @@
 #extension GL_EXT_control_flow_attributes : require
 #extension GL_ARB_shading_language_include : enable
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_atomic_float : require
 
 #include "PerFrame.glsl"
 
@@ -54,6 +55,19 @@ uint laneID = gl_LocalInvocationID.x;
 
 #include "AlphaShape.glsl"
 
+vec3 ComputeTriangleNormal(vec3 v0, vec3 v1, vec3 v2) {
+    // Compute the two edges of the triangle
+    vec3 edge1 = v1 - v0;
+    vec3 edge2 = v2 - v0;
+
+    // Compute the cross product of the two edges to get the normal
+    vec3 normal = cross(edge1, edge2);
+
+    // Normalize the result to ensure the normal has unit length
+    return normalize(normal);
+}
+
+
 void main(){
 
 	BARRIER();
@@ -76,6 +90,25 @@ void main(){
 			delaunay_tetrahedrons[tet_id].neighbor_circumference[triangle_index] = min_distance_squared;
 			if(delaunay_tetrahedrons[tet_id].render_neighbor[triangle_index] == 1){
 				atomicAdd(delaunay_tetrahedrons[tet_id].triangles_accepted, 1);
+
+				// compute triangle normal
+				vec3 v[3];
+
+				int index = 0;
+				for(int i = 0; i < 4; i++){
+					if(i != triangle_index){
+						v[index] = uniform_particles[tet.indices[i]].position_t.xyz;
+						index++;
+					}
+				}
+
+				vec4 normal_deg = vec4(ComputeTriangleNormal(v[0], v[1], v[2]), 1.0f);
+
+				// add normal to all triangle vertices, so we can later compute an average
+				atomicAdd(uniform_particles[tet.indices[i]].normal_deg.x, normal_deg.x);
+				atomicAdd(uniform_particles[tet.indices[i]].normal_deg.y, normal_deg.y);
+				atomicAdd(uniform_particles[tet.indices[i]].normal_deg.z, normal_deg.z);
+				atomicAdd(uniform_particles[tet.indices[i]].normal_deg.w, normal_deg.w);
 			}
 		}
 	}
@@ -94,11 +127,23 @@ void main(){
 		uint vertex_index = laneID + i * WORKGROUP_SIZE;
 		if (vertex_index >= TETRAHEDRON_VERTICES_SIZE) break;
 		vec3 vertex_position = uniform_particles[tet.indices[vertex_index]].position_t.xyz;
+		vec3 vertex_normal = normalize(uniform_particles[tet.indices[vertex_index]].normal_deg.xyz);
 
 		ms_v_out[vertex_index].frag_pos = vertex_position;
-		ms_v_out[vertex_index].normal = vec3(0, 1, 0);
-		ms_v_out[vertex_index].tangent = vec3(0, 0, 1);
-		ms_v_out[vertex_index].color = vec4(0.5, 0.5, 0.5, 1.0);
+		ms_v_out[vertex_index].normal = vertex_normal;
+		ms_v_out[vertex_index].tangent = uniform_particles[tet.indices[vertex_index]].tangent.xyz;
+		if(vertex_colors == 0){
+			ms_v_out[vertex_index].color = vec4(0.5, 0.5, 0.5, 1.0);
+		} else if(vertex_colors == 1){
+			ms_v_out[vertex_index].color = vec4(abs(vertex_normal.xyz), 1.0f);
+		} else if(vertex_colors == 2){
+			ms_v_out[vertex_index].color = vec4(abs(uniform_particles[tet.indices[vertex_index]].tangent.xyz), 1.0f);
+		} else if(vertex_colors == 3){
+			ms_v_out[vertex_index].color = vec4(mod(uniform_particles[tet.indices[vertex_index]].tex_coord.x, 1.0f),
+				mod(uniform_particles[tet.indices[vertex_index]].tex_coord.y, 1.0f),
+				mod(uniform_particles[tet.indices[vertex_index]].tex_coord.z, 1.0f), 1.0f);
+		}
+
 		gl_MeshVerticesEXT[vertex_index].gl_Position = transform * vec4(vertex_position, 1.0);
 	}
 

--- a/EvoEngine_Plugins/EcoSysLab/Internals/EcoSysLabResources/Shaders/Includes/AlphaShape.glsl
+++ b/EvoEngine_Plugins/EcoSysLab/Internals/EcoSysLabResources/Shaders/Includes/AlphaShape.glsl
@@ -6,6 +6,7 @@ layout(push_constant) uniform STRANDS_RENDER_CONSTANTS {
   float alpha;
   float bifurcation_alpha;
   int render_complex;
+  int vertex_colors;
 };
 
 void SortFourElements(inout uint a[4]) {

--- a/EvoEngine_Plugins/EcoSysLab/Internals/EcoSysLabResources/Shaders/Includes/DynamicStrands.glsl
+++ b/EvoEngine_Plugins/EcoSysLab/Internals/EcoSysLabResources/Shaders/Includes/DynamicStrands.glsl
@@ -22,6 +22,9 @@ struct Strand {
 
 struct Node {
   int prev_handle;
+  int padding0;
+  int padding1;
+  int padding2;
 };
 
 struct Segment {
@@ -124,6 +127,9 @@ struct SegmentData {
 
 struct UniformParticle {
   vec4 position_t;
+  vec4 normal_deg;
+  vec4 tangent;
+  vec4 tex_coord;
   int segment_handle;
   int node_index;
   int segment_index;

--- a/EvoEngine_Plugins/EcoSysLab/include/DynamicStrands/DynamicStrands.hpp
+++ b/EvoEngine_Plugins/EcoSysLab/include/DynamicStrands/DynamicStrands.hpp
@@ -113,6 +113,8 @@ class DynamicStrands {
     GlobalTransform root_transform{};
     bool use_cgal = false;
     bool triangulate_per_bundle = false;
+    int u_multiplier = 2;
+    float v_multiplier = 0.25;
 
     bool OnInspect(const std::shared_ptr<EditorLayer>& editor_layer);
   };
@@ -186,8 +188,10 @@ class DynamicStrands {
     bool render_complex = false;
     bool use_cgal = false;
     bool wireframe = false;
-    float alpha = 1.0f / 10000.0f;
-    float bifurcation_alpha = 1.0f / 10000.0f;
+    float alpha = 1.0 / 10000.0f;
+    float bifurcation_alpha = 1.0 / 10000.0f;
+    enum VertexColors {Default, Normals, Tangents, TexCoords};
+    VertexColors vertex_colors = Default;
     bool OnInspect(const std::shared_ptr<EditorLayer>& editor_layer);
   };
 
@@ -221,6 +225,9 @@ class DynamicStrands {
 
   struct GpuNode {
     int prev_handle = -1;
+    int padding0;
+    int padding1;
+    int padding2;
   };
 
   struct GpuSegment {
@@ -338,6 +345,11 @@ class DynamicStrands {
   struct GpuUniformParticle {
     glm::vec3 position;
     float t;
+    glm::vec3 normal;
+    float deg;
+    glm::vec3 tangent;
+    int padding0;
+    glm::vec4 tex_coord;
     int segment_handle;
     int node_index;
     int segment_index;

--- a/EvoEngine_Plugins/EcoSysLab/include/MeshFormation/MeshGenUtils.hpp
+++ b/EvoEngine_Plugins/EcoSysLab/include/MeshFormation/MeshGenUtils.hpp
@@ -2,8 +2,6 @@
 
 #include "Delaunator2D.hpp"
 
-#include "Delaunator2D.hpp"
-
 namespace eco_sys_lab_plugin {
 
 /// @brief An undirected graph represented as an unordered adjacency list

--- a/EvoEngine_Plugins/EcoSysLab/include/StrandModel/UVMapUtils.hpp
+++ b/EvoEngine_Plugins/EcoSysLab/include/StrandModel/UVMapUtils.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "StrandModel.hpp"
+
+namespace eco_sys_lab_plugin {
+
+class UVMapUtils {
+ public:
+  UVMapUtils();
+  ~UVMapUtils();
+
+  static bool IsValidPipeParam(const StrandModel& strand_model, const StrandHandle& pipe_handle, float t);
+
+  static float GetPipePolar(const Particle2D<CellParticlePhysicsData>& p0, const Particle2D<CellParticlePhysicsData>& p1,
+                     float t);
+
+  static float GetPipePolar(const StrandModel& strand_model, const StrandHandle& pipe_handle, float t);
+
+  static const Particle2D<CellParticlePhysicsData>& GetEndParticle(const StrandModel& strand_model,
+                                                                   const StrandHandle& pipe_handle, size_t index);
+
+  static const Particle2D<CellParticlePhysicsData>& GetEndParticle(const StrandModelSkeleton& skeleton,
+                                                            const StrandHandle& pipe_handle, size_t index);
+
+  static const Particle2D<CellParticlePhysicsData>& GetStartParticle(const StrandModel& strand_model,
+                                                                     const StrandHandle& pipe_handle, size_t index);
+
+  static const Particle2D<CellParticlePhysicsData>& GetStartParticle(const StrandModelSkeleton& skeleton,
+                                                              const StrandHandle& pipe_handle, size_t index);
+
+};
+
+}  // namespace eco_sys_lab_plugin

--- a/EvoEngine_Plugins/EcoSysLab/src/DynamicStrands.cpp
+++ b/EvoEngine_Plugins/EcoSysLab/src/DynamicStrands.cpp
@@ -4,6 +4,7 @@
 #include "DsPhysics.hpp"
 #include "DynamicStrandUtils.hpp"
 #include "Shader.hpp"
+#include "UVMapUtils.hpp"
 #include "glm/gtc/matrix_access.hpp"
 #include "glm/gtx/quaternion.hpp"
 using namespace eco_sys_lab_plugin;
@@ -188,6 +189,19 @@ bool DynamicStrands::InitializeParameters::OnInspect(const std::shared_ptr<Edito
       changed = true;
     PlottedDistributionSettings max_twist_strain_settings{};
     if (max_twist_strain.OnInspect("Max twist strain", max_twist_strain_settings))
+      changed = true;
+
+    ImGui::TreePop();
+  }
+  if (ImGui::TreeNode("Meshing Properties")) {
+#ifdef USE_CGAL
+    if (ImGui::Checkbox("Use CGAL", &use_cgal))
+      changed = true;
+#endif  // USE_CGAL
+    if (ImGui::DragInt("u-coordinate multiplier", &u_multiplier, 2, 2, 20))
+      changed = true;
+
+    if (ImGui::DragFloat("v-coordinate multiplier", &v_multiplier, 0.001f, 0.0f, 100.0f))
       changed = true;
 
     ImGui::TreePop();
@@ -440,6 +454,17 @@ void DynamicStrands::Initialize(const InitializeParameters& initialize_parameter
     const auto& particle1 = particles[segment.particle1_handle];
 
     uniform_particle.position = glm::mix(particle0.x0, particle1.x0, uniform_particle.t);
+    uniform_particle.normal = glm::vec3(0.0f);
+    uniform_particle.deg = 0.0f;
+
+    // set up UV map
+    const auto& p0 = UVMapUtils::GetEndParticle(strand_model_skeleton, uniform_particle.strand_index,
+                                                glm::floor(uniform_particle.t));
+    const auto& p1 = UVMapUtils::GetStartParticle(strand_model_skeleton, uniform_particle.strand_index,
+                                                  glm::floor(uniform_particle.t));
+    uniform_particle.tex_coord.x = UVMapUtils::GetPipePolar(p0, p1, uniform_particle.t) / (2 * glm::pi<float>()) *
+                                   initialize_parameters.u_multiplier;
+    uniform_particle.tex_coord.y = uniform_particle.node_index * initialize_parameters.v_multiplier;
   });
   segment_data_list.resize(segments.size());
   std::vector<glm::vec3> max_bounds(Jobs::GetWorkerSize());

--- a/EvoEngine_Plugins/EcoSysLab/src/DynamicStrandsRendering.cpp
+++ b/EvoEngine_Plugins/EcoSysLab/src/DynamicStrandsRendering.cpp
@@ -13,6 +13,14 @@ bool DynamicStrands::RenderParameters::OnInspect(const std::shared_ptr<EditorLay
   ImGui::Checkbox("Wireframe", &wireframe);
   ImGui::DragFloat("alpha", &alpha, 0.000001, 0.0f, 1.0f, "%.6f");
   ImGui::DragFloat("bifurcation alpha", &bifurcation_alpha, 0.000001, 0.0f, 1.0f, "%.6f");
+
+  ImGui::Text("Use vertex color for visualization");
+
+  ImGui::RadioButton("Disabled", (int*) &vertex_colors, Default);
+  ImGui::RadioButton("Normals", (int*) &vertex_colors, Normals);
+  ImGui::RadioButton("Tangents", (int*) &vertex_colors, Tangents);
+  ImGui::RadioButton("Texture coordinates", (int*)&vertex_colors, TexCoords);
+
   return false;
 }
 
@@ -40,6 +48,7 @@ void DynamicStrands::Render(const std::shared_ptr<Camera>& target_camera,
     float alpha = 0.0f;
     float bifurcation_alpha = 0.0f;
     int render_complex = 0;
+    int vertex_colors = 0;
   };
 
   if (!render_pipeline) {
@@ -93,6 +102,7 @@ void DynamicStrands::Render(const std::shared_ptr<Camera>& target_camera,
   push_constant.alpha = render_parameters.alpha;
   push_constant.bifurcation_alpha = render_parameters.bifurcation_alpha;
   push_constant.render_complex = render_parameters.render_complex ? 1 : 0;
+  push_constant.vertex_colors = render_parameters.vertex_colors;
 
 #ifdef USE_RENDERDOC
   if (rdoc_api) {

--- a/EvoEngine_Plugins/EcoSysLab/src/IterativeSlicingMeshGenerator.cpp
+++ b/EvoEngine_Plugins/EcoSysLab/src/IterativeSlicingMeshGenerator.cpp
@@ -2,6 +2,7 @@
 #include <glm/gtx/intersect.hpp>
 #include <glm/gtx/io.hpp>
 #include "MeshGenUtils.hpp"
+#include "UVMapUtils.hpp"
 
 #define DEBUG_OUTPUT false
 
@@ -38,11 +39,6 @@ SkeletonNodeHandle GetNodeHandle(const StrandModelStrandGroup& pipe_group, const
   return strand_segment_data.node_handle;
 }
 
-bool IsValidPipeParam(const StrandModel& strand_model, const StrandHandle& pipe_handle, float t) {
-  const auto& pipe = strand_model.strand_model_skeleton.data.strand_group.PeekStrand(pipe_handle);
-  return pipe.PeekStrandSegmentHandles().size() > glm::floor(t);
-}
-
 glm::vec3 GetPipeDir(const StrandModel& strand_model, const StrandHandle& pipe_handle, float t) {
   const auto& pipe = strand_model.strand_model_skeleton.data.strand_group.PeekStrand(pipe_handle);
   const auto seg_handle = pipe.PeekStrandSegmentHandles()[t];
@@ -50,91 +46,6 @@ glm::vec3 GetPipeDir(const StrandModel& strand_model, const StrandHandle& pipe_h
 }
 
 void SetStrandColor(StrandModel& strand_model, const StrandHandle& pipe_handle, float t, glm::vec4 color) {
-}
-
-const Particle2D<CellParticlePhysicsData>& GetEndParticle(const StrandModel& strand_model,
-                                                          const StrandHandle& pipe_handle, size_t index) {
-  if (!IsValidPipeParam(strand_model, pipe_handle, index)) {
-    EVOENGINE_ERROR("Error: Strand " << pipe_handle << " does not exist at " << index);
-  }
-
-  const auto& skeleton = strand_model.strand_model_skeleton;
-  const auto& pipe = skeleton.data.strand_group.PeekStrand(pipe_handle);
-  StrandSegmentHandle seg_handle = pipe.PeekStrandSegmentHandles()[index];
-  auto& pipe_segment_data = skeleton.data.strand_group.PeekStrandSegmentData(seg_handle);
-
-  const auto& node = skeleton.PeekNode(pipe_segment_data.node_handle);
-  const auto& start_profile = node.data.profile;
-  // To access the user's defined constraints (attractors, etc.)
-  const auto& profile_constraints = node.data.profile_constraints;
-
-  // To access the position of the start of the pipe segment within a boundary:
-  const auto parent_handle = node.GetParentHandle();
-  const auto& end_particle = start_profile.PeekParticle(pipe_segment_data.profile_particle_handle);
-
-  return end_particle;
-}
-
-const Particle2D<CellParticlePhysicsData>& GetStartParticle(const StrandModel& strand_model,
-                                                            const StrandHandle& pipe_handle, size_t index) {
-  if (!IsValidPipeParam(strand_model, pipe_handle, index)) {
-    EVOENGINE_ERROR("Strand " << pipe_handle << " does not exist at " << index);
-  }
-
-  const auto& skeleton = strand_model.strand_model_skeleton;
-  const auto& pipe = skeleton.data.strand_group.PeekStrand(pipe_handle);
-  const auto seg_handle = pipe.PeekStrandSegmentHandles()[index];
-  auto& strand_segment_data = skeleton.data.strand_group.PeekStrandSegmentData(seg_handle);
-
-  const auto& node = skeleton.PeekNode(strand_segment_data.node_handle);
-  const auto& start_profile = node.data.profile;
-  // To access the user's defined constraints (attractors, etc.)
-  const auto& profile_constraints = node.data.profile_constraints;
-  // To access the position of the start of the pipe segment within a boundary:
-  const auto& start_particle = start_profile.PeekParticle(strand_segment_data.profile_particle_handle);
-  return start_particle;
-}
-
-float GetPipePolar(const StrandModel& strand_model, const StrandHandle& pipe_handle, float t) {
-  // cheap interpolation, maybe improve this later ?
-  const auto& p0 = GetStartParticle(strand_model, pipe_handle, std::floor(t));
-  const auto& p1 = GetEndParticle(strand_model, pipe_handle, std::floor(t));
-  float a1 = p1.GetPolarPosition().y;
-
-  if (IsValidPipeParam(strand_model, pipe_handle, std::ceil(t))) {
-    const auto& p1 = GetStartParticle(strand_model, pipe_handle, std::ceil(t));
-    a1 = p1.GetPolarPosition().y;
-  }
-
-  float a0 = p0.GetPolarPosition().y;
-
-  float interpolation_param = fmod(t, 1.0f);
-
-  // we will just assume that the difference cannot exceed 180 degrees
-  if (a1 < a0) {
-    std::swap(a0, a1);
-    interpolation_param = 1 - interpolation_param;
-  }
-
-  float angle;
-
-  if (a1 - a0 > glm::pi<float>()) {
-    // rotation wraps around
-    angle =
-        fmod((a0 + 2 * glm::pi<float>()) * (1 - interpolation_param) + a1 * interpolation_param, 2 * glm::pi<float>());
-
-    if (angle > glm::pi<float>()) {
-      angle -= 2 * glm::pi<float>();
-    }
-  } else {
-    angle = a0 * (1 - interpolation_param) + a1 * interpolation_param;
-
-    if (angle > glm::pi<float>()) {
-      angle -= 2 * glm::pi<float>();
-    }
-  }
-
-  return angle;
 }
 
 std::vector<size_t> CollectComponent(const Graph& g, size_t start_index) {
@@ -185,7 +96,7 @@ std::pair<Graph, std::vector<size_t>> ComputeCluster(const StrandModel& strand_m
                                                      const PipeCluster& pipes_in_previous, size_t index,
                                                      std::vector<bool>& visited, float t, float max_dist,
                                                      size_t min_strand_count) {
-  if (!IsValidPipeParam(strand_model, pipes_in_previous[index], t)) {
+  if (!UVMapUtils::IsValidPipeParam(strand_model, pipes_in_previous[index], t)) {
     return std::make_pair<>(Graph(), std::vector<size_t>());
   }
   // sweep over tree from root to leaves to reconstruct a skeleton with bark outlines
@@ -223,7 +134,7 @@ std::pair<Graph, std::vector<size_t>> ComputeCluster(const StrandModel& strand_m
   glm::vec3 max(-std::numeric_limits<float>::infinity());
 
   for (auto& pipe_handle : pipes_in_previous) {
-    if (!IsValidPipeParam(strand_model, pipe_handle, t)) {
+    if (!UVMapUtils::IsValidPipeParam(strand_model, pipe_handle, t)) {
       // discard this pipe
       size_t v_index = strand_graph.addVertex();
       visited[v_index] = true;
@@ -780,7 +691,7 @@ void CreateTwigTip(const StrandModel& strand_model, std::pair<Slice, PipeCluster
   glm::vec3 pos(0, 0, 0);
 
   for (auto& el : prev_slice.second) {
-    if (!IsValidPipeParam(strand_model, el, t)) {
+    if (!UVMapUtils::IsValidPipeParam(strand_model, el, t)) {
       t -= 0.01;
     }
 
@@ -875,7 +786,8 @@ std::vector<SlicingData> Slicing(const StrandModel& strand_model, std::vector<Sl
 
       glm::vec2 tex_coord;
       tex_coord.y = t * settings.v_multiplier;
-      tex_coord.x = (GetPipePolar(strand_model, el.first, t) / (2 * glm::pi<float>()) + accumulated_angle / 360.0f) *
+      tex_coord.x =
+          (UVMapUtils::GetPipePolar(strand_model, el.first, t) / (2 * glm::pi<float>()) + accumulated_angle / 360.0f) *
                     settings.u_multiplier;
 
       // add twisting to uv-Coordinates
@@ -1107,7 +1019,8 @@ void IterativeSlicingMeshGenerator::Generate(const StrandModel& strand_model, st
 
       glm::vec2 tex_coord;
       tex_coord.y = 0.0;
-      tex_coord.x = GetPipePolar(strand_model, el.first, 0.0) / (2 * glm::pi<float>()) * settings.u_multiplier;
+      tex_coord.x =
+          UVMapUtils::GetPipePolar(strand_model, el.first, 0.0) / (2 * glm::pi<float>()) * settings.u_multiplier;
 
       // add twisting to uv-Coordinates
       auto node_handle = GetNodeHandle(pipe_group, el.first, 0);

--- a/EvoEngine_Plugins/EcoSysLab/src/UVMapUtils.cpp
+++ b/EvoEngine_Plugins/EcoSysLab/src/UVMapUtils.cpp
@@ -1,0 +1,114 @@
+#include "UVMapUtils.hpp"
+
+using namespace eco_sys_lab_plugin;
+
+UVMapUtils::UVMapUtils() {
+}
+
+UVMapUtils::~UVMapUtils() {
+}
+
+bool UVMapUtils::IsValidPipeParam(const StrandModel& strand_model, const StrandHandle& pipe_handle, float t) {
+  const auto& pipe = strand_model.strand_model_skeleton.data.strand_group.PeekStrand(pipe_handle);
+  return pipe.PeekStrandSegmentHandles().size() > glm::floor(t);
+}
+
+float UVMapUtils::GetPipePolar(const Particle2D<CellParticlePhysicsData>& p0, const Particle2D<CellParticlePhysicsData>& p1, float t) {
+  float a0 = p0.GetPolarPosition().y;
+  float a1 = p1.GetPolarPosition().y;
+
+  float interpolation_param = fmod(t, 1.0f);
+
+  // we will just assume that the difference cannot exceed 180 degrees
+  if (a1 < a0) {
+    std::swap(a0, a1);
+    interpolation_param = 1 - interpolation_param;
+  }
+
+  float angle;
+
+  if (a1 - a0 > glm::pi<float>()) {
+    // rotation wraps around
+    angle =
+        fmod((a0 + 2 * glm::pi<float>()) * (1 - interpolation_param) + a1 * interpolation_param, 2 * glm::pi<float>());
+
+    if (angle > glm::pi<float>()) {
+      angle -= 2 * glm::pi<float>();
+    }
+  } else {
+    angle = a0 * (1 - interpolation_param) + a1 * interpolation_param;
+
+    if (angle > glm::pi<float>()) {
+      angle -= 2 * glm::pi<float>();
+    }
+  }
+
+  return angle;
+}
+
+float UVMapUtils::GetPipePolar(const StrandModel& strand_model, const StrandHandle& pipe_handle, float t) {
+  // cheap interpolation, maybe improve this later ?
+  const auto& p0 = GetStartParticle(strand_model, pipe_handle, std::floor(t));
+  const auto& p1 = GetEndParticle(strand_model, pipe_handle, std::floor(t));
+
+  if (IsValidPipeParam(strand_model, pipe_handle, std::ceil(t))) {
+    const auto& p1 = GetStartParticle(strand_model, pipe_handle, std::ceil(t));
+  }
+
+  return GetPipePolar(p0, p1, t);
+}
+
+const Particle2D<CellParticlePhysicsData>& UVMapUtils::GetEndParticle(const StrandModel& strand_model,
+                                                                      const StrandHandle& pipe_handle, size_t index) {
+  if (!IsValidPipeParam(strand_model, pipe_handle, index)) {
+    EVOENGINE_ERROR("Error: Strand " << pipe_handle << " does not exist at " << index);
+  }
+
+  const auto& skeleton = strand_model.strand_model_skeleton;
+
+  return GetEndParticle(skeleton, pipe_handle, index);
+}
+
+const Particle2D<CellParticlePhysicsData>& UVMapUtils::GetEndParticle(const StrandModelSkeleton& skeleton,
+                                                          const StrandHandle& pipe_handle, size_t index) {  
+  const auto& pipe = skeleton.data.strand_group.PeekStrand(pipe_handle);
+  StrandSegmentHandle seg_handle = pipe.PeekStrandSegmentHandles()[index];
+  auto& pipe_segment_data = skeleton.data.strand_group.PeekStrandSegmentData(seg_handle);
+
+  const auto& node = skeleton.PeekNode(pipe_segment_data.node_handle);
+  const auto& start_profile = node.data.profile;
+  // To access the user's defined constraints (attractors, etc.)
+  const auto& profile_constraints = node.data.profile_constraints;
+
+  // To access the position of the start of the pipe segment within a boundary:
+  const auto parent_handle = node.GetParentHandle();
+  const auto& end_particle = start_profile.PeekParticle(pipe_segment_data.profile_particle_handle);
+
+  return end_particle;
+}
+
+const Particle2D<CellParticlePhysicsData>& UVMapUtils::GetStartParticle(const StrandModel& strand_model,
+                                                                        const StrandHandle& pipe_handle, size_t index) {
+  if (!IsValidPipeParam(strand_model, pipe_handle, index)) {
+    EVOENGINE_ERROR("Strand " << pipe_handle << " does not exist at " << index);
+  }
+
+  const auto& skeleton = strand_model.strand_model_skeleton;
+
+  return GetStartParticle(skeleton, pipe_handle, index);
+}
+
+const Particle2D<CellParticlePhysicsData>& UVMapUtils::GetStartParticle(
+    const StrandModelSkeleton& skeleton, const StrandHandle& pipe_handle, size_t index) {
+  const auto& pipe = skeleton.data.strand_group.PeekStrand(pipe_handle);
+  const auto seg_handle = pipe.PeekStrandSegmentHandles()[index];
+  auto& strand_segment_data = skeleton.data.strand_group.PeekStrandSegmentData(seg_handle);
+
+  const auto& node = skeleton.PeekNode(strand_segment_data.node_handle);
+  const auto& start_profile = node.data.profile;
+  // To access the user's defined constraints (attractors, etc.)
+  const auto& profile_constraints = node.data.profile_constraints;
+  // To access the position of the start of the pipe segment within a boundary:
+  const auto& start_particle = start_profile.PeekParticle(strand_segment_data.profile_particle_handle);
+  return start_particle;
+}


### PR DESCRIPTION
Normals, tangents and UV coordinates have been implemented for meshes of dynamic strand trees, though normals do not work properly yet. Furthermore, a visualization was implemented using vertex colors.

An option to enable CGAL interactively that was apparently lost somehow has also been reintroduced