### PR TITLE
Bug fix for ImGui Tree Nodes that caused an assertion to fail.

### DIFF
--- a/EvoEngine_Plugins/EcoSysLab/src/EcoSysLabLayerStrands.cpp
+++ b/EvoEngine_Plugins/EcoSysLab/src/EcoSysLabLayerStrands.cpp
@@ -405,12 +405,14 @@ void EcoSysLabLayer::DynamicStrandsSettings::OnInspect(const std::shared_ptr<Edi
     }
     if (ImGui::TreeNodeEx("Render settings", ImGuiTreeNodeFlags_DefaultOpen)) {
       render_parameters.OnInspect(editor_layer);
+      ImGui::TreePop();
     }
     if (ImGui::Button("Rebuild foliage pipelines")) {
       DynamicStrands::BuildFoliageRenderingPipelines();
     }
     if (ImGui::TreeNodeEx("Foliage render settings", ImGuiTreeNodeFlags_DefaultOpen)) {
       foliage_render_parameters.OnInspect(editor_layer);
+      ImGui::TreePop();
     }
     ImGui::TreePop();
   }


### PR DESCRIPTION
ImGui Tree nodes were not popped, this caused the following error in debug builds:

`Assertion failed: SizeOfIDStack == window->IDStack.Size && "PushID/PopID or TreeNode/TreePop Mismatch!"`