### PR TITLE
Overhaul job runtime and asset loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .vscode/
 build/
 
+# Local branch task notes for coding agents
+tasks/
+
 #Docs
 docs/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,16 @@
 
 This file provides repository-wide guidance for coding agents working in EvoEngine.
 
+## Branch Task Tracking
+
+When working on a new branch, create a local `./tasks` directory with these files:
+
+- `todo.md`
+- `in-progress.md`
+- `done.md`
+
+Use these files to keep a brief, current record of planned work, active work, and completed work for the branch. The `./tasks` directory is intentionally git-ignored and should remain local to the working branch/worktree.
+
 ## Commit Workflow
 
 When the user asks you to make a commit:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,4 @@ When the user asks you to make a commit:
 - Make sure the current changes pass all relevant tests before committing.
 - If a full test run is not practical or cannot be completed, run the most relevant subset and clearly report what was and was not verified.
 - Always update the README or other documentation when the change makes documentation inaccurate, incomplete, or missing.
+- Do not include signs of AI/tool usage in commit summaries, commit messages, pull request titles, or pull request descriptions.

--- a/EvoEngine_App/src/DemoApp.cpp
+++ b/EvoEngine_App/src/DemoApp.cpp
@@ -1,8 +1,12 @@
 #include "Application.hpp"
 #include "DemoScene.hpp"
 #include "EditorLayer.hpp"
+#include "Platform.hpp"
+#include "ProjectManager.hpp"
 #include "RenderLayer.hpp"
 #include "WindowLayer.hpp"
+
+#include <cstdlib>
 
 #ifdef PHYSX_PHYSICS_SERVICE
 #  include "PhysicsLayer.hpp"
@@ -10,23 +14,203 @@
 
 using namespace evo_engine;
 
-int main() {
+namespace {
+enum class DemoAppRunMode { Normal, SmokeTest };
+
+struct DemoAppRuntimeConfig {
+  DemoAppRunMode mode = DemoAppRunMode::Normal;
+  DemoSetup demo_setup = DemoSetup::Rendering;
+  size_t frames_after_play = 100;
+  size_t max_load_frames = 30000;
+  size_t max_play_frames = 1000;
+  bool exit_on_complete = true;
+};
+
+std::optional<std::filesystem::path> FindRunConfigPath(const int argc, char** argv) {
+  for (int arg_index = 1; arg_index < argc; ++arg_index) {
+    const std::string argument = argv[arg_index] ? argv[arg_index] : "";
+    if (argument == "--run-config") {
+      if (arg_index + 1 >= argc) {
+        throw std::invalid_argument("--run-config requires a path.");
+      }
+      return std::filesystem::absolute(argv[arg_index + 1]);
+    }
+    throw std::invalid_argument("Unknown DemoApp argument: " + argument);
+  }
+
+  std::vector<std::filesystem::path> candidates;
+  if (argc > 0 && argv[0]) {
+    candidates.emplace_back(std::filesystem::absolute(argv[0]).parent_path() / "DemoApp.run.yaml");
+  }
+  candidates.emplace_back(std::filesystem::current_path() / "DemoApp.run.yaml");
+  for (const auto& candidate : candidates) {
+    if (std::filesystem::exists(candidate)) {
+      return candidate;
+    }
+  }
+  return {};
+}
+
+DemoSetup ParseDemoSetup(const std::string& value) {
+  if (value == "Empty") {
+    return DemoSetup::Empty;
+  }
+  if (value == "Rendering") {
+    return DemoSetup::Rendering;
+  }
+  if (value == "Universe") {
+    return DemoSetup::Universe;
+  }
+  throw std::invalid_argument("Unknown demo_setup value: " + value);
+}
+
+DemoAppRuntimeConfig LoadRunConfig(const std::filesystem::path& path) {
+  const YAML::Node root = YAML::LoadFile(path.string());
+  if (!root || !root.IsMap()) {
+    throw std::runtime_error("DemoApp run config must be a YAML map.");
+  }
+
+  DemoAppRuntimeConfig config;
+  if (const auto mode = root["mode"]) {
+    const auto mode_name = mode.as<std::string>();
+    if (mode_name == "normal") {
+      config.mode = DemoAppRunMode::Normal;
+    } else if (mode_name == "smoke_test") {
+      config.mode = DemoAppRunMode::SmokeTest;
+    } else {
+      throw std::invalid_argument("Unknown mode value: " + mode_name);
+    }
+  }
+  if (const auto demo_setup = root["demo_setup"]) {
+    config.demo_setup = ParseDemoSetup(demo_setup.as<std::string>());
+  }
+  if (const auto frames_after_play = root["frames_after_play"]) {
+    config.frames_after_play = frames_after_play.as<size_t>();
+  }
+  if (const auto max_load_frames = root["max_load_frames"]) {
+    config.max_load_frames = max_load_frames.as<size_t>();
+  }
+  if (const auto max_play_frames = root["max_play_frames"]) {
+    config.max_play_frames = max_play_frames.as<size_t>();
+  }
+  if (const auto exit_on_complete = root["exit_on_complete"]) {
+    config.exit_on_complete = exit_on_complete.as<bool>();
+  }
+  return config;
+}
+
+int FailSmokeTest(Application& application, const std::string& reason) {
+  if (application.IsPlaying()) {
+    application.Stop();
+  }
+  application.End();
+  std::cerr << "EVOENGINE_APP_TEST_RESULT failed reason=\"" << reason << "\"" << std::endl;
+  return 1;
+}
+
+int RunSmokeTest(const DemoAppRuntimeConfig& config) {
+  auto& application = ApplicationContext::Get();
+  application.Start(false);
+
+  size_t load_frame_count = 0;
+  while (!ProjectManager::IsProjectIdle()) {
+    if (!application.Loop()) {
+      return FailSmokeTest(application, "application ended before project load completed");
+    }
+    ++load_frame_count;
+    if (load_frame_count >= config.max_load_frames) {
+      return FailSmokeTest(application, "project load timed out");
+    }
+  }
+
+  if (!ProjectManager::GetStartScene().lock()) {
+    return FailSmokeTest(application, "start scene is missing after project load");
+  }
+  if (!application.GetActiveScene()) {
+    return FailSmokeTest(application, "active scene is missing after project load");
+  }
+
+  const auto loaded_frame = Platform::GetFrameCount();
+  application.Play();
+  if (!application.IsPlaying()) {
+    return FailSmokeTest(application, "application did not enter play mode");
+  }
+
+  const auto play_start_frame = Platform::GetFrameCount();
+  size_t play_loop_count = 0;
+  while (Platform::GetFrameCount() - play_start_frame < config.frames_after_play) {
+    if (!application.Loop()) {
+      return FailSmokeTest(application, "application ended before requested play frames completed");
+    }
+    ++play_loop_count;
+    if (play_loop_count >= config.max_play_frames) {
+      return FailSmokeTest(application, "play frame wait timed out");
+    }
+  }
+
+  std::cout << "EVOENGINE_APP_TEST_RESULT passed"
+            << " loaded_frame=" << loaded_frame << " play_start_frame=" << play_start_frame
+            << " final_frame=" << Platform::GetFrameCount() << std::endl;
+  if (!config.exit_on_complete) {
+    application.Run();
+  } else {
+    application.Stop();
+    application.End();
+  }
+  return 0;
+}
+}  // namespace
+
+int main(const int argc, char** argv) {
   Application application;
-  constexpr DemoSetup demo_setup = DemoSetup::Rendering;
-  ApplicationContext::Get().PushLayer<RenderLayer>("Render Layer");
-  ApplicationContext::Get().PushLayer<WindowLayer>("Window Layer");
-  ApplicationContext::Get().PushLayer<EditorLayer>("Editor Layer");
+  bool initialized = false;
+  bool smoke_test = false;
+  try {
+    const auto run_config_path = FindRunConfigPath(argc, argv);
+    std::optional<DemoAppRuntimeConfig> runtime_config;
+    if (run_config_path) {
+      runtime_config = LoadRunConfig(*run_config_path);
+    }
+    const auto demo_setup = runtime_config ? runtime_config->demo_setup : DemoSetup::Rendering;
+
+    ApplicationContext::Get().PushLayer<RenderLayer>("Render Layer");
+    ApplicationContext::Get().PushLayer<WindowLayer>("Window Layer");
+    ApplicationContext::Get().PushLayer<EditorLayer>("Editor Layer");
 #ifdef PHYSX_PHYSICS_SERVICE
-  ApplicationContext::Get().PushLayer<PhysicsLayer>();
+    ApplicationContext::Get().PushLayer<PhysicsLayer>();
 #endif
 
-  ApplicationInitializationSettings application_info;
-  SetupDemoScene(demo_setup, application_info);
+    ApplicationInitializationSettings application_info;
+    SetupDemoScene(demo_setup, application_info);
 
-  ApplicationContext::Get().Initialize(application_info);
+    ApplicationContext::Get().Initialize(application_info);
+    initialized = true;
 
-  ApplicationContext::Get().Start();
-  ApplicationContext::Get().Run();
-  ApplicationContext::Get().Terminate();
-  return 0;
+    int exit_code = 0;
+    smoke_test = runtime_config && runtime_config->mode == DemoAppRunMode::SmokeTest;
+    if (smoke_test) {
+      exit_code = RunSmokeTest(*runtime_config);
+    } else {
+      ApplicationContext::Get().Start();
+      ApplicationContext::Get().Run();
+    }
+    ApplicationContext::Get().Terminate();
+    if (smoke_test) {
+      std::cout.flush();
+      std::cerr.flush();
+      std::_Exit(exit_code);
+    }
+    return exit_code;
+  } catch (const std::exception& e) {
+    std::cerr << "EVOENGINE_APP_TEST_RESULT failed reason=\"" << e.what() << "\"" << std::endl;
+    if (initialized) {
+      ApplicationContext::Get().Terminate();
+    }
+    if (smoke_test) {
+      std::cout.flush();
+      std::cerr.flush();
+      std::_Exit(1);
+    }
+    return 1;
+  }
 }

--- a/EvoEngine_SDK/include/ApplicationInitializationSettings.hpp
+++ b/EvoEngine_SDK/include/ApplicationInitializationSettings.hpp
@@ -48,6 +48,9 @@ struct ApplicationInitializationSettings {
   bool enable_docking = true;                    /**< Whether to enable docking in the application. */
   bool enable_viewport = true;                   /**< Whether to enable the viewport feature. */
   bool full_screen = false;                      /**< Whether the application starts in full-screen mode. */
+  bool load_default_resources = true;            /**< Whether to load built-in default rendering resources. */
+  bool load_project_assets = true;               /**< Whether project open should load all discovered project assets. */
+  bool load_project_start_scene = true;          /**< Whether project open should load/create and attach a scene. */
   bool enable_runtime_packages = false;          /**< Whether to load runtime packages during initialization. */
   std::vector<std::filesystem::path> package_search_paths; /**< Additional runtime package search paths. */
   std::vector<std::string> startup_runtime_packages;       /**< Runtime packages to load during initialization. */

--- a/EvoEngine_SDK/include/Core/AssetManager.hpp
+++ b/EvoEngine_SDK/include/Core/AssetManager.hpp
@@ -1,6 +1,11 @@
 
 #pragma once
+#include <deque>
+#include <future>
+#include <functional>
+#include <set>
 #include <stack>
+#include <vector>
 
 #include "IHandle.hpp"
 #include "Serialization.hpp"
@@ -17,6 +22,24 @@ class IAsset;
  */
 class AssetManager {
  public:
+  enum class AssetLoadState { Discovered, Queued, LoadingCpu, WaitingForFinalize, Loaded, Failed, Cancelled };
+
+  struct AssetLoadSnapshot {
+    size_t total = 0;
+    size_t completed = 0;
+    size_t failed = 0;
+    size_t cancelled = 0;
+    size_t queued = 0;
+    size_t loading_cpu = 0;
+    size_t waiting_for_finalize = 0;
+    Handle active_asset_handle = 0;
+    AssetLoadState active_state = AssetLoadState::Discovered;
+    std::string active_asset_name;
+    std::string message;
+
+    [[nodiscard]] bool Active() const;
+  };
+
   static AssetManager& GetInstance();
 
  private:
@@ -60,6 +83,27 @@ class AssetManager {
    */
   [[nodiscard]] static std::shared_ptr<IAsset> GetAsset(const Handle& asset_handle);
 
+  /**
+   * @brief Enqueues an asset load request and returns the shared future without blocking the caller.
+   */
+  [[nodiscard]] static std::shared_future<std::shared_ptr<IAsset>> RequestAssetLoad(const Handle& asset_handle);
+
+  /**
+   * @brief Enqueues a batch of asset loads for project/UI progress tracking.
+   */
+  [[nodiscard]] static std::vector<std::shared_future<std::shared_ptr<IAsset>>> RequestAssetLoads(
+      const std::set<Handle>& asset_handles);
+
+  /**
+   * @brief Returns a thread-safe snapshot of the current asset-service loading progress.
+   */
+  [[nodiscard]] static AssetLoadSnapshot GetAssetLoadSnapshot();
+
+  /**
+   * @brief Runs queued main-thread asset construction/finalization tasks.
+   */
+  static size_t ExecuteMainThreadAssetTasks(size_t max_task_size = 1);
+
  private:
   /**
    * @brief Retrieves an asset given its typename and handle.
@@ -74,8 +118,23 @@ class AssetManager {
    * @brief Internal registry for managing assets and their corresponding handles.
    */
   class AssetRegistry {
+    struct AssetLoadingRecord {
+      std::shared_future<std::shared_ptr<IAsset>> future;  ///< Shared result for all waiters on the asset load.
+      std::weak_ptr<IAsset> loading_asset;                 ///< Partially constructed asset for same-thread recursion.
+      std::thread::id owner_thread_id;                     ///< Thread currently performing the load.
+      bool async = false;                                  ///< Whether this record was created by async access.
+      bool allow_same_thread_partial_access =
+          false;  ///< True only while a synchronous Load() call may recursively request itself.
+      AssetLoadState state = AssetLoadState::Discovered;
+      std::string asset_name;
+      std::string message;
+    };
+
     std::mutex asset_registry_mutex;  ///< Mutex for synchronizing access to the asset registry.
     std::unordered_map<Handle, std::weak_ptr<IAsset>> assets_;  ///< Map storing assets by their handles.
+    std::unordered_map<Handle, AssetLoadingRecord> loading_assets_;  ///< In-flight loads by asset handle.
+    std::deque<std::function<void()>> main_thread_asset_tasks_;       ///< Asset tasks that must run on main.
+    AssetLoadSnapshot load_snapshot_;                                 ///< Current asset-service progress snapshot.
 
     friend class AssetManager;  ///< AssetManager has access to private members of AssetRegistry.
   };
@@ -141,11 +200,51 @@ class AssetManager {
   static std::shared_ptr<IAsset> GetAssetImpl(const Handle& asset_handle);
 
   /**
+   * @brief Performs the actual uncached asset creation and load work for a handle.
+   */
+  static std::shared_ptr<IAsset> LoadAssetImpl(const Handle& asset_handle);
+
+  /**
+   * @brief Starts service-thread loading for an asset request.
+   */
+  static void StartAssetServiceLoadImpl(const Handle& asset_handle,
+                                        const std::shared_ptr<std::promise<std::shared_ptr<IAsset>>>& promise);
+
+  /**
+   * @brief Waits for a load future while allowing the main thread to run queued finalization tasks.
+   */
+  static std::shared_ptr<IAsset> WaitForAssetLoadFutureImpl(
+      const std::shared_future<std::shared_ptr<IAsset>>& asset_future);
+
+  /**
+   * @brief Gets or creates the shared in-flight load for an asset handle.
+   */
+  static std::shared_future<std::shared_ptr<IAsset>> GetOrCreateAssetLoadFutureImpl(const Handle& asset_handle,
+                                                                                    bool async);
+
+  static void ScheduleMainThreadAssetTaskImpl(const std::function<void()>& action);
+
+  static void ResetAssetLoadSnapshotImpl(size_t total);
+
+  static void UpdateAssetLoadStateImpl(const Handle& asset_handle, AssetLoadState state, const std::string& message);
+
+  /**
+   * @brief Publishes the partially constructed asset for same-thread recursive access during Load().
+   */
+  static void SetLoadingAssetImpl(const Handle& asset_handle, const std::shared_ptr<IAsset>& asset,
+                                  bool allow_same_thread_partial_access);
+
+  /**
+   * @brief Clears the in-flight load record for an asset handle.
+   */
+  static void FinishAssetLoadingImpl(const Handle& asset_handle);
+
+  /**
    * @brief Retrieves a future object for asynchronously accessing an asset given its handle.
    * @param asset_handle The handle associated with the asset.
-   * @return A future containing a shared pointer to the requested asset.
+   * @return A shared future containing a shared pointer to the requested asset.
    */
-  static std::future<std::shared_ptr<IAsset>> GetAssetFutureImpl(const Handle& asset_handle);
+  static std::shared_future<std::shared_ptr<IAsset>> GetAssetFutureImpl(const Handle& asset_handle);
 };
 
 /**
@@ -158,7 +257,7 @@ template <typename T>
 std::shared_ptr<T> AssetManager::GetAsset(const Handle& asset_handle) {
   try {
     const auto type_name = Serialization::GetSerializableTypeName<T>();
-    return GetAsset(type_name, asset_handle);
+    return std::dynamic_pointer_cast<T>(GetAsset(type_name, asset_handle));
   } catch (const std::exception& e) {
     EVOENGINE_ERROR(e.what());
     return {};
@@ -174,7 +273,10 @@ std::shared_ptr<T> AssetManager::GetAsset(const Handle& asset_handle) {
 template <typename T>
 std::shared_future<std::shared_ptr<T>> AssetManager::GetAssetFuture(const Handle& asset_handle) {
   try {
-    return std::dynamic_pointer_cast<T>(GetAssetFutureImpl(asset_handle));
+    auto asset_future = GetAssetFutureImpl(asset_handle);
+    return std::async(std::launch::deferred, [asset_future = std::move(asset_future)]() mutable {
+      return std::dynamic_pointer_cast<T>(WaitForAssetLoadFutureImpl(asset_future));
+    }).share();
   } catch (const std::exception& e) {
     EVOENGINE_ERROR(e.what());
     return {};

--- a/EvoEngine_SDK/include/Core/AssetManager.hpp
+++ b/EvoEngine_SDK/include/Core/AssetManager.hpp
@@ -1,8 +1,8 @@
 
 #pragma once
 #include <deque>
-#include <future>
 #include <functional>
+#include <future>
 #include <set>
 #include <stack>
 #include <vector>
@@ -131,10 +131,10 @@ class AssetManager {
     };
 
     std::mutex asset_registry_mutex;  ///< Mutex for synchronizing access to the asset registry.
-    std::unordered_map<Handle, std::weak_ptr<IAsset>> assets_;  ///< Map storing assets by their handles.
+    std::unordered_map<Handle, std::weak_ptr<IAsset>> assets_;       ///< Map storing assets by their handles.
     std::unordered_map<Handle, AssetLoadingRecord> loading_assets_;  ///< In-flight loads by asset handle.
-    std::deque<std::function<void()>> main_thread_asset_tasks_;       ///< Asset tasks that must run on main.
-    AssetLoadSnapshot load_snapshot_;                                 ///< Current asset-service progress snapshot.
+    std::deque<std::function<void()>> main_thread_asset_tasks_;      ///< Asset tasks that must run on main.
+    AssetLoadSnapshot load_snapshot_;                                ///< Current asset-service progress snapshot.
 
     friend class AssetManager;  ///< AssetManager has access to private members of AssetRegistry.
   };
@@ -274,9 +274,11 @@ template <typename T>
 std::shared_future<std::shared_ptr<T>> AssetManager::GetAssetFuture(const Handle& asset_handle) {
   try {
     auto asset_future = GetAssetFutureImpl(asset_handle);
-    return std::async(std::launch::deferred, [asset_future = std::move(asset_future)]() mutable {
-      return std::dynamic_pointer_cast<T>(WaitForAssetLoadFutureImpl(asset_future));
-    }).share();
+    return std::async(std::launch::deferred,
+                      [asset_future = std::move(asset_future)]() mutable {
+                        return std::dynamic_pointer_cast<T>(WaitForAssetLoadFutureImpl(asset_future));
+                      })
+        .share();
   } catch (const std::exception& e) {
     EVOENGINE_ERROR(e.what());
     return {};

--- a/EvoEngine_SDK/include/Core/ECS/IAsset.hpp
+++ b/EvoEngine_SDK/include/Core/ECS/IAsset.hpp
@@ -15,6 +15,15 @@ class Folder;
 class Texture2D;
 
 /**
+ * @class StagedAssetLoadPayload
+ * @brief CPU-side data produced by an async-safe asset load phase and consumed by the finalization phase.
+ */
+class StagedAssetLoadPayload {
+ public:
+  virtual ~StagedAssetLoadPayload() = default;
+};
+
+/**
  * @class IAsset
  * @brief Base class for managing assets in the evo_engine framework. Provides functionality for serialization,
  *        deserialization, and interactions with the asset's file system and the editor.
@@ -55,6 +64,28 @@ class IAsset : public ISerializable {
    * @return Whether the load operation was successful.
    */
   virtual bool LoadInternal(const std::filesystem::path& path);
+
+  /**
+   * @brief Returns whether this asset can split disk/decode work from finalization.
+   */
+  [[nodiscard]] virtual bool SupportsStagedLoading() const;
+
+  /**
+   * @brief Returns whether this asset can split disk/decode work from finalization for a specific path.
+   */
+  [[nodiscard]] virtual bool SupportsStagedLoading(const std::filesystem::path& path) const;
+
+  /**
+   * @brief Builds an immutable CPU-side load payload. This must not touch global registries or GPU resources.
+   */
+  [[nodiscard]] virtual std::shared_ptr<StagedAssetLoadPayload> LoadStagedPayloadInternal(
+      const std::filesystem::path& path) const;
+
+  /**
+   * @brief Applies a staged load payload on a safe finalization thread.
+   */
+  virtual bool ApplyStagedPayloadInternal(const std::filesystem::path& path,
+                                          const std::shared_ptr<StagedAssetLoadPayload>& payload);
 
   bool saved_ = false;   /**< Indicates whether the asset is in a saved state. */
   uint32_t version_ = 0; /**< The version number of the asset. */

--- a/EvoEngine_SDK/include/Core/ECS/JobSystem.hpp
+++ b/EvoEngine_SDK/include/Core/ECS/JobSystem.hpp
@@ -1,213 +1,37 @@
-
 #pragma once
+
+#include "TaskRuntime.hpp"
 
 namespace evo_engine {
 
-/**
- * @class JobHandle
- * @brief Represents a handle to a job, used to track and manage job states.
- */
-class JobHandle {
-  int index_ = -1;  ///< Index of the job handle.
-  friend class JobSystem;
-
- public:
-  /**
-   * @brief Gets the index associated with the job handle.
-   * @return The index of the job handle.
-   */
-  [[nodiscard]] int GetIndex() const;
-
-  /**
-   * @brief Checks if the job handle is valid.
-   * @return True if the job handle is valid, otherwise false.
-   */
-  [[nodiscard]] bool Valid() const;
-};
+using JobHandle = TaskHandle;
+using JobGroup = TaskGroup;
+using JobExecutorType = TaskExecutorType;
+using JobPriority = TaskPriority;
+using JobThreadAffinity = ThreadAffinity;
+using JobOptions = TaskOptions;
+using JobRuntimeSettings = TaskRuntimeSettings;
+using JobRuntimeStats = TaskRuntimeStats;
+using JobCancellationToken = CancellationToken;
+using JobCancellationSource = CancellationSource;
 
 /**
- * @class JobSystem
- * @brief Manages a system of jobs for parallel execution.
+ * @brief Backward-compatible job system facade over TaskRuntime.
+ *
+ * Existing code can keep using JobSystem and Jobs while new code targets the generic TaskRuntime executor model.
  */
-class JobSystem {
-  /**
-   * @class JobSystemSemaphore
-   * @brief A semaphore for job synchronization.
-   */
-  class JobSystemSemaphore {
-    size_t availability_ = 0;     ///< The current availability count of the semaphore.
-    std::mutex update_mutex_;     ///< Mutex for synchronizing semaphore updates.
-    std::condition_variable cv_;  ///< Condition variable to signal semaphore availability.
-
-   public:
-    /**
-     * @brief Resets the semaphore to a specified availability count.
-     * @param availability The initial availability count. Default is 0.
-     */
-    void Reset(size_t availability = 0);
-
-    /**
-     * @brief Acquires the semaphore, decrementing its count.
-     */
-    void Acquire();
-
-    /**
-     * @brief Releases the semaphore, incrementing its count.
-     */
-    void Release();
-  };
-
-  /**
-   * @struct Job
-   * @brief Represents a single executable job in the job system.
-   */
-  struct Job {
-    std::vector<JobHandle> parents;         ///< Parent jobs that this job depends on.
-    std::vector<JobHandle> children;        ///< Child jobs dependent on this job.
-    JobHandle job_handle;                   ///< Handle associated with this job.
-    JobSystemSemaphore finished_semaphore;  ///< Semaphore indicating when the job is complete.
-    bool recycled = false;                  ///< Flag indicating if the job has been recycled.
-    bool finished = false;                  ///< Flag indicating if the job is finished.
-    bool wake = false;                      ///< Flag indicating if the job system should wake up to handle this job.
-    std::function<void()> task;             ///< The function to execute as part of the job.
-  };
-
-  /**
-   * @class JobPool
-   * @brief A pool for managing the availability of jobs.
-   */
-  class JobPool {
-   public:
-    /**
-     * @brief Pushes a new job onto the pool.
-     * @param job A pair consisting of a JobHandle and the associated function.
-     */
-    void Push(std::pair<JobHandle, std::function<void()>>&& job);
-
-    /**
-     * @brief Pops a job from the pool if available.
-     * @param job Output parameter to store the retrieved job pair.
-     * @return True if a job was retrieved, otherwise false.
-     */
-    [[nodiscard]] bool Pop(std::pair<JobHandle, std::function<void()>>& job);
-
-    /**
-     * @brief Checks if the job pool is empty.
-     * @return True if the job pool is empty, otherwise false.
-     */
-    [[nodiscard]] bool Empty();
-
-   private:
-    std::queue<std::pair<JobHandle, std::function<void()>>> job_queue_;  ///< Queue holding job pairs.
-    std::mutex pool_mutex_;  ///< Mutex for synchronizing access to the job queue.
-  };
-
-  std::vector<std::shared_ptr<Job>> jobs_;  ///< List of all jobs managed by the system.
-  std::queue<JobHandle> recycled_jobs_;     ///< Queue of recycled job handles.
-  JobPool available_job_pool_;              ///< Pool of available jobs.
-
-  /**
-   * @brief Checks if the current thread is the main thread.
-   * @return True if the current thread is the main thread, otherwise false.
-   */
-  [[nodiscard]] bool MainThreadCheck() const;
-
-  /**
-   * @brief Helper function to collect descendant jobs recursively.
-   * @param jobs A vector to collect the descendant jobs.
-   * @param walker The current job handle to traverse from.
-   */
-  void CollectDescendantsHelper(std::vector<JobHandle>& jobs, const JobHandle& walker);
-
-  /**
-   * @brief Helper function to check if a job is available.
-   * @param job_handle The handle of the job to check.
-   */
-  void CheckJobAvailableHelper(const JobHandle& job_handle);
-
-  /**
-   * @brief Reports that a job has finished execution.
-   * @param job_handle The handle of the finished job.
-   */
-  void ReportFinish(const JobHandle& job_handle);
-
-  /**
-   * @brief Initializes a worker thread by its index.
-   * @param worker_index The index of the worker thread to initialize.
-   */
-  void InitializeWorker(size_t worker_index);
-
-  std::atomic<int> idle_thread_amount_;                    ///< Number of idle threads.
-  std::vector<std::unique_ptr<std::thread>> workers_;      ///< Worker threads.
-  std::vector<std::shared_ptr<std::atomic<bool>>> flags_;  ///< Flags indicating worker states.
-  std::atomic<bool> is_done_;                              ///< Flag indicating if the job system is shutting down.
-
-  std::mutex job_management_mutex_;                  ///< Mutex for managing jobs.
-  std::mutex job_availability_mutex_;                ///< Mutex for handling job availability.
-  std::condition_variable job_available_condition_;  ///< Condition variable for job availability notifications.
-
-  std::thread::id main_thread_id_;  ///< ID of the main thread.
-
+class JobSystem : public TaskRuntime {
  public:
-  /**
-   * @brief Stops all worker threads.
-   */
   void StopAllWorkers();
-
-  /**
-   * @brief Gets the number of currently idle workers.
-   * @return The number of idle workers.
-   */
   [[nodiscard]] size_t IdleWorkerSize() const;
-
-  /**
-   * @brief Constructs the JobSystem.
-   */
-  JobSystem();
-
-  /**
-   * @brief Cleanup function to be called during destruction.
-   */
   void OnDestroy();
-
-  /**
-   * @brief Destructs the JobSystem.
-   */
-  ~JobSystem();
-
-  /**
-   * @brief Resizes the number of worker threads in the system.
-   * @param worker_size The new number of worker threads.
-   */
   void ResizeWorker(size_t worker_size);
-
-  /**
-   * @brief Gets the current number of worker threads.
-   * @return The number of worker threads.
-   */
   [[nodiscard]] size_t GetWorkerSize() const;
 
-  /**
-   * @brief Pushes a new job into the job system. Job will be in pending start state.
-   * @details This function must be executed on the thread where current job system is created.
-   * @param dependencies The list of jobs that must be completed before this job starts.
-   * @param func The function to execute as part of the job.
-   * @return A handle representing the pushed job.
-   */
   [[nodiscard]] JobHandle PushJob(const std::vector<JobHandle>& dependencies, std::function<void()>&& func);
-
-  /**
-   * @brief Start execution of the scheduled job.
-   * @details This function must be executed on the thread where current job system is created.
-   * @param job_handle The handle of the job to execute.
-   */
+  [[nodiscard]] JobHandle PushJob(const std::vector<JobHandle>& dependencies, const JobOptions& options,
+                                  std::function<void()>&& func);
   void ExecuteJob(const JobHandle& job_handle);
-
-  /**
-   * @brief Waits for the completion of a job.
-   * @details This function must be executed on the thread where current job system is created.
-   * @param job_handle The handle of the job to wait for.
-   */
   void Wait(const JobHandle& job_handle);
 };
 

--- a/EvoEngine_SDK/include/Core/ECS/Jobs.hpp
+++ b/EvoEngine_SDK/include/Core/ECS/Jobs.hpp
@@ -29,6 +29,28 @@ class Jobs final {
   static void Initialize(size_t worker_size);
 
   /**
+   * @brief Retrieves runtime diagnostic counters for queued, running, completed, and failed tasks.
+   */
+  static JobRuntimeStats GetRuntimeStats();
+
+  /**
+   * @brief Returns whether the caller is on the application main thread tracked by the runtime.
+   */
+  [[nodiscard]] static bool IsMainThread();
+
+  /**
+   * @brief Returns whether the caller is running on a specific runtime executor.
+   */
+  [[nodiscard]] static bool IsExecutorThread(JobExecutorType executor);
+
+  /**
+   * @brief Executes ready main-thread tasks. Must be called from the application main thread.
+   * @param max_task_size Optional cap. Zero means drain all currently ready tasks.
+   * @return Number of executed tasks.
+   */
+  static size_t ExecuteMainThreadJobs(size_t max_task_size = 0);
+
+  /**
    * @brief Completes a parallel for-loop job on the given function across the specified range.
    * @param size The number of iterations to process.
    * @param func The function to execute for each iteration, taking the index as a parameter.
@@ -116,6 +138,12 @@ class Jobs final {
   static JobHandle Run(const std::vector<JobHandle>& dependencies, const std::function<void()>& func);
 
   /**
+   * @brief Schedules a job with explicit runtime options. Job will be in pending start state.
+   */
+  static JobHandle Run(const std::vector<JobHandle>& dependencies, const JobOptions& options,
+                       const std::function<void()>& func);
+
+  /**
    * @brief Schedules a job executing the given function without dependencies. Job will be in pending start state.
    * @param func The function to execute.
    * @return A JobHandle representing the scheduled job.
@@ -123,11 +151,41 @@ class Jobs final {
   static JobHandle Run(const std::function<void()>& func);
 
   /**
+   * @brief Schedules a job with explicit runtime options and no dependencies. Job will be in pending start state.
+   */
+  static JobHandle Run(const JobOptions& options, const std::function<void()>& func);
+
+  /**
+   * @brief Schedules a job for the application main-thread executor.
+   */
+  static JobHandle RunOnMainThread(const std::function<void()>& func);
+
+  /**
+   * @brief Schedules a job for the asset IO executor.
+   */
+  static JobHandle RunOnAssetIoThread(const std::function<void()>& func);
+
+  /**
+   * @brief Schedules a job for the render executor.
+   */
+  static JobHandle RunOnRenderThread(const std::function<void()>& func);
+
+  /**
+   * @brief Schedules a job for the background executor.
+   */
+  static JobHandle RunOnBackgroundThread(const std::function<void()>& func);
+
+  /**
    * @brief Combines multiple jobs into a single job.
    * @param dependencies A vector of JobHandle representing dependent jobs.
    * @return A JobHandle combining the dependencies.
    */
   static JobHandle Combine(const std::vector<JobHandle>& dependencies);
+
+  /**
+   * @brief Combines a task group into a single dependency handle.
+   */
+  static JobHandle Combine(const JobGroup& job_group);
 
   /**
    * @brief Start execution of the scheduled job.

--- a/EvoEngine_SDK/include/Core/ECS/Prefab.hpp
+++ b/EvoEngine_SDK/include/Core/ECS/Prefab.hpp
@@ -139,6 +139,23 @@ class Prefab : public IAsset {
   [[nodiscard]] bool LoadInternal(const std::filesystem::path& path) override;
 
   /**
+   * @brief Native prefab YAML can be parsed as staged work; model import remains legacy.
+   */
+  [[nodiscard]] bool SupportsStagedLoading(const std::filesystem::path& path) const override;
+
+  /**
+   * @brief Parses a native prefab YAML file into a staged payload.
+   */
+  [[nodiscard]] std::shared_ptr<StagedAssetLoadPayload> LoadStagedPayloadInternal(
+      const std::filesystem::path& path) const override;
+
+  /**
+   * @brief Reconstructs prefab-local assets and prefab data from a staged YAML payload.
+   */
+  bool ApplyStagedPayloadInternal(const std::filesystem::path& path,
+                                  const std::shared_ptr<StagedAssetLoadPayload>& payload) override;
+
+  /**
    * @brief Saves the prefab asset to a specified file path.
    * @param[in] path The path to the file to save to.
    * @return True if saving is successful; otherwise false.

--- a/EvoEngine_SDK/include/Core/ECS/Scene.hpp
+++ b/EvoEngine_SDK/include/Core/ECS/Scene.hpp
@@ -1253,6 +1253,23 @@ class Scene final : public IAsset {
    * @return True if the scene was loaded successfully, false otherwise.
    */
   bool LoadInternal(const std::filesystem::path& path) override;
+
+  /**
+   * @brief Scene YAML can be parsed off-thread, but scene reconstruction must finalize on the main thread.
+   */
+  [[nodiscard]] bool SupportsStagedLoading(const std::filesystem::path& path) const override;
+
+  /**
+   * @brief Parses scene YAML into a staged payload.
+   */
+  [[nodiscard]] std::shared_ptr<StagedAssetLoadPayload> LoadStagedPayloadInternal(
+      const std::filesystem::path& path) const override;
+
+  /**
+   * @brief Reconstructs the scene from a staged YAML payload.
+   */
+  bool ApplyStagedPayloadInternal(const std::filesystem::path& path,
+                                  const std::shared_ptr<StagedAssetLoadPayload>& payload) override;
 };
 template <typename T>
 std::vector<Entity> Scene::GetPrivateComponentOwnersList() {

--- a/EvoEngine_SDK/include/Core/ECS/TaskRuntime.hpp
+++ b/EvoEngine_SDK/include/Core/ECS/TaskRuntime.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <atomic>
-#include <cstdint>
 #include <condition_variable>
+#include <cstdint>
 #include <deque>
 #include <exception>
 #include <functional>

--- a/EvoEngine_SDK/include/Core/ECS/TaskRuntime.hpp
+++ b/EvoEngine_SDK/include/Core/ECS/TaskRuntime.hpp
@@ -1,0 +1,258 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <condition_variable>
+#include <deque>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace evo_engine {
+
+/**
+ * @brief Logical execution lanes owned by the engine runtime.
+ */
+enum class TaskExecutorType { MainThread, Worker, AssetIo, Render, Background };
+
+/**
+ * @brief Queue priority within an executor.
+ */
+enum class TaskPriority { Low, Normal, High };
+
+/**
+ * @brief Optional hard affinity for tasks that must run on a specific lane.
+ */
+enum class ThreadAffinity { Any, MainThread, Worker, AssetIo, Render, Background };
+
+/**
+ * @brief Read-only cancellation view checked before a task starts execution.
+ */
+class CancellationToken {
+  std::shared_ptr<std::atomic<bool>> state_;
+
+  explicit CancellationToken(std::shared_ptr<std::atomic<bool>> state);
+  friend class CancellationSource;
+
+ public:
+  CancellationToken() = default;
+  [[nodiscard]] bool IsCancellationRequested() const;
+  [[nodiscard]] bool Valid() const;
+};
+
+/**
+ * @brief Owns cancellation state that can be shared with scheduled tasks.
+ */
+class CancellationSource {
+  std::shared_ptr<std::atomic<bool>> state_ = std::make_shared<std::atomic<bool>>(false);
+
+ public:
+  [[nodiscard]] CancellationToken GetToken() const;
+  void Cancel() const;
+  [[nodiscard]] bool IsCancellationRequested() const;
+};
+
+/**
+ * @brief Generation-checked handle for a scheduled task.
+ */
+class TaskHandle {
+  int index_ = -1;
+  uint32_t generation_ = 0;
+
+  friend class TaskRuntime;
+
+ public:
+  [[nodiscard]] int GetIndex() const;
+  [[nodiscard]] uint32_t GetGeneration() const;
+  [[nodiscard]] bool Valid() const;
+};
+
+/**
+ * @brief Small dependency collection used when building task graphs incrementally.
+ */
+class TaskGroup {
+  std::vector<TaskHandle> handles_;
+
+ public:
+  void Add(const TaskHandle& handle);
+  void Clear();
+  [[nodiscard]] bool Empty() const;
+  [[nodiscard]] const std::vector<TaskHandle>& GetHandles() const;
+};
+
+/**
+ * @brief Scheduling options for executor selection, priority, cancellation, and diagnostics.
+ */
+struct TaskOptions {
+  TaskExecutorType executor = TaskExecutorType::Worker;
+  TaskPriority priority = TaskPriority::Normal;
+  ThreadAffinity affinity = ThreadAffinity::Any;
+  CancellationToken cancellation_token;
+  std::string debug_name;
+};
+
+/**
+ * @brief Thread counts for the engine-owned task runtime.
+ */
+struct TaskRuntimeSettings {
+  size_t worker_thread_size = 1;
+  size_t asset_io_thread_size = 1;
+  size_t render_thread_size = 1;
+  size_t background_thread_size = 1;
+};
+
+/**
+ * @brief Runtime counters intended for diagnostics and editor tooling.
+ */
+struct TaskRuntimeStats {
+  size_t worker_thread_size = 0;
+  size_t asset_io_thread_size = 0;
+  size_t render_thread_size = 0;
+  size_t background_thread_size = 0;
+  size_t queued_task_size = 0;
+  size_t running_task_size = 0;
+  size_t submitted_task_size = 0;
+  size_t completed_task_size = 0;
+  size_t failed_task_size = 0;
+};
+
+/**
+ * @brief Engine-owned task scheduler with a worker pool plus named always-on service executors.
+ *
+ * TaskRuntime is intentionally the stable abstraction boundary for the engine. Higher-level systems should depend on
+ * this API instead of a third-party scheduler directly; the backend can be replaced later after focused bake-offs.
+ */
+class TaskRuntime {
+  enum class TaskState { Pending, Queued, Running, Completed, Recycled };
+
+  struct TaskRecord {
+    uint32_t generation = 1;
+    TaskState state = TaskState::Recycled;
+    std::vector<TaskHandle> dependencies;
+    std::vector<TaskHandle> dependents;
+    size_t pending_dependency_size = 0;
+    bool scheduled = false;
+    TaskOptions options;
+    std::function<void()> function;
+    std::exception_ptr exception;
+  };
+
+  struct ExecutorState {
+    TaskExecutorType type = TaskExecutorType::Worker;
+    std::string name;
+    std::vector<std::unique_ptr<std::thread>> threads;
+    std::deque<TaskHandle> high_priority_tasks;
+    std::deque<TaskHandle> normal_priority_tasks;
+    std::deque<TaskHandle> low_priority_tasks;
+    mutable std::mutex mutex;
+    std::condition_variable cv;
+    bool stopping = false;
+    size_t queued_task_size = 0;
+  };
+
+  std::thread::id main_thread_id_;
+  ExecutorState main_executor_;
+  ExecutorState worker_executor_;
+  ExecutorState asset_io_executor_;
+  ExecutorState render_executor_;
+  ExecutorState background_executor_;
+
+  mutable std::mutex task_mutex_;
+  std::condition_variable task_finished_cv_;
+  std::vector<std::shared_ptr<TaskRecord>> tasks_;
+  std::queue<int> recycled_task_indices_;
+
+  std::atomic<bool> shutting_down_{false};
+  std::atomic<size_t> running_task_size_{0};
+  std::atomic<size_t> submitted_task_size_{0};
+  std::atomic<size_t> completed_task_size_{0};
+  std::atomic<size_t> failed_task_size_{0};
+
+  [[nodiscard]] bool IsHandleValidLocked(const TaskHandle& handle) const;
+  [[nodiscard]] static bool ExecutorHasTasks(const ExecutorState& executor);
+  [[nodiscard]] static std::deque<TaskHandle>& GetQueueForPriority(ExecutorState& executor, TaskPriority priority);
+  [[nodiscard]] ExecutorState& GetExecutor(TaskExecutorType executor);
+  [[nodiscard]] const ExecutorState& GetExecutor(TaskExecutorType executor) const;
+  [[nodiscard]] ExecutorState& GetRunnableExecutor(TaskExecutorType executor);
+  [[nodiscard]] TaskHandle AllocateTaskLocked();
+
+  void StartExecutor(ExecutorState& executor, size_t thread_size, const std::string& name);
+  void StopExecutor(ExecutorState& executor);
+  void ExecutorLoop(ExecutorState& executor);
+  void QueueReadyTask(const TaskHandle& handle);
+  void QueueReadyTasks(const std::vector<TaskHandle>& handles);
+  [[nodiscard]] bool TryPopTask(ExecutorState& executor, TaskHandle& handle);
+  [[nodiscard]] bool TryPopTaskForWaiting(TaskHandle& handle, TaskExecutorType& executor);
+  void RunTask(const TaskHandle& handle, TaskExecutorType executor);
+
+  void StartTaskGraphLocked(const TaskHandle& handle, std::vector<TaskHandle>& ready_tasks,
+                            std::vector<int>& visited_indices);
+  void CollectTaskTreeLocked(const TaskHandle& handle, std::vector<TaskHandle>& task_tree) const;
+  [[nodiscard]] bool CanRecycleTaskLocked(const TaskHandle& handle) const;
+  void RecycleTaskLocked(const TaskHandle& handle);
+
+ public:
+  TaskRuntime();
+  ~TaskRuntime();
+  TaskRuntime(const TaskRuntime&) = delete;
+  TaskRuntime& operator=(const TaskRuntime&) = delete;
+
+  /**
+   * @brief Starts the configured executor threads and resets runtime counters.
+   */
+  void Initialize(const TaskRuntimeSettings& settings);
+
+  /**
+   * @brief Stops all executor threads, clears queued tasks, and invalidates outstanding handles.
+   */
+  void Shutdown();
+
+  /**
+   * @brief Resizes only the general worker pool. Service executors keep their configured sizes.
+   */
+  void ResizeWorker(size_t worker_size);
+
+  [[nodiscard]] size_t GetWorkerSize() const;
+  [[nodiscard]] size_t GetThreadSize(TaskExecutorType executor) const;
+  [[nodiscard]] bool IsMainThread() const;
+  [[nodiscard]] bool IsExecutorThread(TaskExecutorType executor) const;
+  [[nodiscard]] TaskRuntimeStats GetStats() const;
+
+  /**
+   * @brief Creates a pending task. Call Execute or Wait on the returned handle to start its dependency graph.
+   */
+  [[nodiscard]] TaskHandle Schedule(const std::vector<TaskHandle>& dependencies, const TaskOptions& options,
+                                    std::function<void()>&& function);
+  [[nodiscard]] TaskHandle Schedule(const std::vector<TaskHandle>& dependencies, std::function<void()>&& function);
+  [[nodiscard]] TaskHandle Schedule(std::function<void()>&& function);
+
+  /**
+   * @brief Creates a no-op task that completes after all dependencies complete.
+   */
+  [[nodiscard]] TaskHandle Combine(const std::vector<TaskHandle>& dependencies);
+  [[nodiscard]] TaskHandle Combine(const TaskGroup& task_group);
+
+  /**
+   * @brief Starts the selected task and all unscheduled dependencies.
+   */
+  void Execute(const TaskHandle& handle);
+
+  /**
+   * @brief Starts the task graph, helps execute eligible work while waiting, and rethrows task exceptions.
+   */
+  void Wait(const TaskHandle& handle);
+  [[nodiscard]] bool IsCompleted(const TaskHandle& handle) const;
+  [[nodiscard]] std::exception_ptr GetException(const TaskHandle& handle) const;
+
+  /**
+   * @brief Drains ready main-thread tasks. Must be called from the runtime's main thread.
+   */
+  size_t RunReadyMainThreadTasks(size_t max_task_size = 0);
+};
+
+}  // namespace evo_engine

--- a/EvoEngine_SDK/include/Core/ProjectManager.hpp
+++ b/EvoEngine_SDK/include/Core/ProjectManager.hpp
@@ -66,8 +66,9 @@ class ProjectManager {
 
   bool scan_assets_pending = false;  ///< Indicates if an asset scan is pending.
 
-  size_t pending_asset_size = 0;    ///< The count of assets pending to be processed.
-  std::set<Handle> pending_assets;  ///< The list of handles to pending assets.
+  bool project_asset_load_dispatched = false;  ///< True while a project asset batch is owned by AssetManager.
+  size_t pending_asset_size = 0;               ///< The count of assets pending to be processed.
+  std::set<Handle> pending_assets;             ///< The list of handles to pending assets.
 
   /**
    * @brief Scans and updates the asset list based on the current assets folder.
@@ -99,6 +100,11 @@ class ProjectManager {
    * @return A weak pointer to the starting scene.
    */
   [[nodiscard]] static std::weak_ptr<Scene> GetStartScene();
+
+  /**
+   * @brief Returns true when project scanning, project asset loading, and start-scene setup are complete.
+   */
+  [[nodiscard]] static bool IsProjectIdle();
 
   /**
    * @brief Sets the starting scene for the project.
@@ -225,6 +231,3 @@ class ProjectManager {
 };
 
 }  // namespace evo_engine
-
-// All methods already documented.
-// Task is complete.

--- a/EvoEngine_SDK/include/Rendering/Animation/Animation.hpp
+++ b/EvoEngine_SDK/include/Rendering/Animation/Animation.hpp
@@ -161,6 +161,10 @@ struct Bone {
  */
 class Animation : public IAsset {
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   std::map<std::string, float> animation_length;  ///< Map of animation names to their lengths.
   std::shared_ptr<Bone> root_bone;                ///< Root bone of the skeleton hierarchy.
   size_t bone_size = 0;                           ///< Total number of bones in the skeleton.

--- a/EvoEngine_SDK/include/Rendering/Geometry/Mesh.hpp
+++ b/EvoEngine_SDK/include/Rendering/Geometry/Mesh.hpp
@@ -41,6 +41,10 @@ class ParticleInfoList final : public IAsset {
   std::shared_ptr<RangeDescriptor> range_descriptor_; /**< Shared pointer to the range descriptor. */
 
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   /**
    * @brief Creates the particle information list asset.
    */
@@ -167,6 +171,10 @@ class Mesh final : public IAsset, public IGeometry {
   bool SaveInternal(const std::filesystem::path& path) const override;
 
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   /**
    * @brief Generates a thumbnail texture for the mesh.
    *

--- a/EvoEngine_SDK/include/Rendering/Geometry/SkinnedMesh.hpp
+++ b/EvoEngine_SDK/include/Rendering/Geometry/SkinnedMesh.hpp
@@ -104,6 +104,10 @@ class SkinnedMesh : public IAsset, public IGeometry {
   bool SaveInternal(const std::filesystem::path& path) const override;
 
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   /**
    * @brief Destructor for SkinnedMesh.
    */

--- a/EvoEngine_SDK/include/Rendering/Geometry/Strands.hpp
+++ b/EvoEngine_SDK/include/Rendering/Geometry/Strands.hpp
@@ -194,6 +194,23 @@ class Strands final : public IAsset, public IGeometry {
    */
   bool LoadInternal(const std::filesystem::path& path) override;
 
+  /**
+   * @brief Strands files can parse CPU buffers before main-thread geometry publication.
+   */
+  [[nodiscard]] bool SupportsStagedLoading(const std::filesystem::path& path) const override;
+
+  /**
+   * @brief Builds staged CPU-side strand buffers.
+   */
+  [[nodiscard]] std::shared_ptr<StagedAssetLoadPayload> LoadStagedPayloadInternal(
+      const std::filesystem::path& path) const override;
+
+  /**
+   * @brief Applies staged strand buffers and publishes geometry storage.
+   */
+  bool ApplyStagedPayloadInternal(const std::filesystem::path& path,
+                                  const std::shared_ptr<StagedAssetLoadPayload>& payload) override;
+
  private:
   std::shared_ptr<RangeDescriptor> segment_range_;         ///< Descriptor for segment range.
   std::shared_ptr<RangeDescriptor> strand_meshlet_range_;  ///< Descriptor for strand meshlet range.

--- a/EvoEngine_SDK/include/Rendering/PBR/EnvironmentalMap.hpp
+++ b/EvoEngine_SDK/include/Rendering/PBR/EnvironmentalMap.hpp
@@ -24,6 +24,10 @@ class EnvironmentalMap final : public IAsset {
   AssetRef inspection_target_texture_;
 
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   /**
    * @brief Reference to the light probe used in the environment.
    */

--- a/EvoEngine_SDK/include/Rendering/PBR/LightProbe.hpp
+++ b/EvoEngine_SDK/include/Rendering/PBR/LightProbe.hpp
@@ -30,6 +30,10 @@ class LightProbe final : public IAsset {
   friend class Camera;
 
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   /**
    * @brief Initializes the light probe with a specified resolution.
    *

--- a/EvoEngine_SDK/include/Rendering/PBR/Material.hpp
+++ b/EvoEngine_SDK/include/Rendering/PBR/Material.hpp
@@ -64,6 +64,10 @@ class Material final : public IAsset {
   AssetRef rma_texture_ref_;    ///< Temporary editor reference for RMA texture unpacking.
 
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   /**
    * @brief Generates a thumbnail texture representing this material.
    * @return A shared pointer to the generated thumbnail texture.

--- a/EvoEngine_SDK/include/Rendering/PBR/ReflectionProbe.hpp
+++ b/EvoEngine_SDK/include/Rendering/PBR/ReflectionProbe.hpp
@@ -19,6 +19,10 @@ class ReflectionProbe : public IAsset {
       mip_map_views_;  ///< A collection of mip map views for the cubemap.
 
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   /**
    * @brief Initializes the reflection probe with a specified resolution.
    * @param resolution The resolution of the cubemap. Default is 512.

--- a/EvoEngine_SDK/include/Rendering/Platform/GraphicsResources.hpp
+++ b/EvoEngine_SDK/include/Rendering/Platform/GraphicsResources.hpp
@@ -872,8 +872,9 @@ class CommandBuffer final : public IGraphicsResource {
   /**
    * @brief Records commands using the specified callback function.
    * @param commands Callback function to record Vulkan commands.
+   * @return True if recording completed successfully.
    */
-  void Record(const std::function<void(VkCommandBuffer vk_command_buffer)>& commands);
+  [[nodiscard]] bool Record(const std::function<void(VkCommandBuffer vk_command_buffer)>& commands);
 
   /**
    * @brief Resets the command buffer to its initial state.

--- a/EvoEngine_SDK/include/Rendering/Platform/Platform.hpp
+++ b/EvoEngine_SDK/include/Rendering/Platform/Platform.hpp
@@ -6,6 +6,7 @@
 #include "GraphicsResources.hpp"
 #include "RayTracingPipeline.hpp"
 
+#include <mutex>
 #include <set>
 
 #define ENABLE_EXTERNAL_MEMORY true
@@ -205,6 +206,9 @@ class Platform final {
 
   /// Immediate submit queue for rendering commands.
   std::unique_ptr<CommandQueue> immediate_submit_queue_{};
+
+  /// Serializes the shared immediate-submit command buffer and queue.
+  std::mutex immediate_submit_mutex_{};
 
   /// Queue used for primary rendering operations.
   std::unique_ptr<CommandQueue> main_queue_{};

--- a/EvoEngine_SDK/include/Rendering/Platform/Shader.hpp
+++ b/EvoEngine_SDK/include/Rendering/Platform/Shader.hpp
@@ -56,6 +56,23 @@ class Shader final : public IAsset {
    */
   [[nodiscard]] bool LoadInternal(const std::filesystem::path& path) override;
 
+  /**
+   * @brief Shader source/YAML can be read and parsed before main-thread finalization.
+   */
+  [[nodiscard]] bool SupportsStagedLoading() const override;
+
+  /**
+   * @brief Builds a CPU-side shader source payload.
+   */
+  [[nodiscard]] std::shared_ptr<StagedAssetLoadPayload> LoadStagedPayloadInternal(
+      const std::filesystem::path& path) const override;
+
+  /**
+   * @brief Applies the staged shader source payload.
+   */
+  bool ApplyStagedPayloadInternal(const std::filesystem::path& path,
+                                  const std::shared_ptr<StagedAssetLoadPayload>& payload) override;
+
  public:
   /**
    * @brief Displays an interface for shader inspection in the editor.

--- a/EvoEngine_SDK/include/Rendering/PostProcessing/PostProcessingStack.hpp
+++ b/EvoEngine_SDK/include/Rendering/PostProcessing/PostProcessingStack.hpp
@@ -20,6 +20,10 @@ class PostProcessingStack : public IAsset {
   std::shared_ptr<DescriptorSet> blur_horizontal_descriptor_set;  // RENDER_TEXTURE_PRESENT_LAYOUT: 0
   std::shared_ptr<DescriptorSet> blur_vertical_descriptor_set;    // RENDER_TEXTURE_PRESENT_LAYOUT: 0
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   std::shared_ptr<RenderTexture> source_color_texture;
   std::shared_ptr<RenderTexture> result_texture;
   std::shared_ptr<RenderTexture> swap_texture;

--- a/EvoEngine_SDK/include/Rendering/Texture/Cubemap.hpp
+++ b/EvoEngine_SDK/include/Rendering/Texture/Cubemap.hpp
@@ -39,6 +39,10 @@ class Cubemap final : public IAsset {
   mutable std::shared_ptr<GraphicsPipeline> equirectangular_to_cubemap_pipeline_;
 
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   /**
    * @struct EquirectangularToCubemapConstant
    * @brief Represents constants used for converting equirectangular textures to cubemaps.

--- a/EvoEngine_SDK/include/Rendering/Texture/Texture2D.hpp
+++ b/EvoEngine_SDK/include/Rendering/Texture/Texture2D.hpp
@@ -27,6 +27,11 @@ class Texture2D : public IAsset {
  protected:
   bool SaveInternal(const std::filesystem::path& path) const override;
   bool LoadInternal(const std::filesystem::path& path) override;
+  [[nodiscard]] bool SupportsStagedLoading() const override;
+  [[nodiscard]] std::shared_ptr<StagedAssetLoadPayload> LoadStagedPayloadInternal(
+      const std::filesystem::path& path) const override;
+  bool ApplyStagedPayloadInternal(const std::filesystem::path& path,
+                                  const std::shared_ptr<StagedAssetLoadPayload>& payload) override;
 
  public:
   void UnsafeUploadDataImmediately() const;

--- a/EvoEngine_SDK/include/Utilities/Json.hpp
+++ b/EvoEngine_SDK/include/Utilities/Json.hpp
@@ -25,6 +25,23 @@ class Json : public IAsset {
    */
   bool LoadInternal(const std::filesystem::path& path) override;
 
+  /**
+   * @brief JSON files can be parsed on the asset-IO executor and applied later.
+   */
+  [[nodiscard]] bool SupportsStagedLoading() const override;
+
+  /**
+   * @brief Parses the JSON file into a staged payload.
+   */
+  [[nodiscard]] std::shared_ptr<StagedAssetLoadPayload> LoadStagedPayloadInternal(
+      const std::filesystem::path& path) const override;
+
+  /**
+   * @brief Applies a parsed JSON staged payload.
+   */
+  bool ApplyStagedPayloadInternal(const std::filesystem::path& path,
+                                  const std::shared_ptr<StagedAssetLoadPayload>& payload) override;
+
  public:
   /// @brief JSON object representing the data of the asset.
   nlohmann::json m_json;

--- a/EvoEngine_SDK/include/Utilities/PointCloud.hpp
+++ b/EvoEngine_SDK/include/Utilities/PointCloud.hpp
@@ -25,6 +25,23 @@ class PointCloud : public IAsset {
   bool LoadInternal(const std::filesystem::path& path) override;
 
   /**
+   * @brief Point cloud file parsing can run as staged CPU work.
+   */
+  [[nodiscard]] bool SupportsStagedLoading(const std::filesystem::path& path) const override;
+
+  /**
+   * @brief Builds CPU-side point cloud data from YAML/PLY input.
+   */
+  [[nodiscard]] std::shared_ptr<StagedAssetLoadPayload> LoadStagedPayloadInternal(
+      const std::filesystem::path& path) const override;
+
+  /**
+   * @brief Applies staged point cloud data to the asset.
+   */
+  bool ApplyStagedPayloadInternal(const std::filesystem::path& path,
+                                  const std::shared_ptr<StagedAssetLoadPayload>& payload) override;
+
+  /**
    * @brief Internal method to save the point cloud to a file.
    * @param path The path to the file to save the point cloud to.
    * @return True if the save is successful, otherwise false.

--- a/EvoEngine_SDK/include/Utilities/ProceduralNoise/ProceduralNoise.hpp
+++ b/EvoEngine_SDK/include/Utilities/ProceduralNoise/ProceduralNoise.hpp
@@ -100,6 +100,10 @@ class ProceduralNoise2D : public IAsset, public IProceduralNoise {
   std::shared_ptr<Texture2D> test_texture_2d_;
 
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   void Reset() override;
   ProceduralNoise2D();
   float GetValue(const glm::vec2& offset) const;
@@ -113,6 +117,10 @@ class ProceduralNoise3D : public IAsset, public IProceduralNoise {
   std::shared_ptr<Texture2D> test_texture_2d_;
 
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   void Reset() override;
   ProceduralNoise3D();
   float GetValue(const glm::vec3& offset) const;
@@ -127,6 +135,10 @@ class ProceduralNoise4D : public IAsset, public IProceduralNoise {
   std::shared_ptr<Texture2D> test_texture_2d_;
 
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
   void Reset() override;
   ProceduralNoise4D();
   float GetValue(const glm::vec4& offset) const;

--- a/EvoEngine_SDK/include/Utilities/UnknownPrivateComponent.hpp
+++ b/EvoEngine_SDK/include/Utilities/UnknownPrivateComponent.hpp
@@ -56,6 +56,9 @@ class UnknownPrivateComponent : public IPrivateComponent, public UnknownRuntimeP
 
 class UnknownAsset : public IAsset, public UnknownRuntimePayload {
  public:
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
   bool OnInspect(const std::shared_ptr<EditorLayer>& editor_layer) override;
   void Serialize(YAML::Emitter& out) const override;
   void Deserialize(const YAML::Node& in) override;

--- a/EvoEngine_SDK/src/Application.cpp
+++ b/EvoEngine_SDK/src/Application.cpp
@@ -3,6 +3,7 @@
 #include "ApplicationContext.hpp"
 
 #include "AnimationPlayer.hpp"
+#include "AssetManager.hpp"
 #include "Cubemap.hpp"
 #include "EditorLayer.hpp"
 #include "EnvironmentalMap.hpp"
@@ -151,7 +152,9 @@ void Application::PreUpdateInternal() {
   if (const auto render_layer = GetLayer<RenderLayer>()) {
     Platform::PreUpdate();
   }
+  AssetManager::ExecuteMainThreadAssetTasks(1);
   ProjectManager::PreUpdate();
+  AssetManager::ExecuteMainThreadAssetTasks(1);
   if (this->active_scene_) {
     TransformGraph::CalculateTransformGraphs(this->active_scene_);
     for (const auto& i : this->external_pre_update_functions_)
@@ -368,11 +371,12 @@ void Application::Initialize(const ApplicationInitializationSettings& applicatio
     EVOENGINE_ERROR("Project filepath must present when there's no EditorLayer or WindowLayer!")
     return;
   }
-  const auto default_thread_size = std::thread::hardware_concurrency();
+  const auto hardware_thread_size = std::thread::hardware_concurrency();
+  const size_t default_thread_size = hardware_thread_size > 2 ? hardware_thread_size - 2 : 1;
   for (const auto& layer : this->layers_) {
     layer->RegisterTypes(*this);
   }
-  Jobs::Initialize(default_thread_size - 2);
+  Jobs::Initialize(default_thread_size);
   Entities::Initialize();
   TransformGraph::Initialize();
   AssetManager::Initialize();
@@ -381,7 +385,9 @@ void Application::Initialize(const ApplicationInitializationSettings& applicatio
   if (render_layer) {
     Platform::Initialize(this->initialization_settings);
   }
-  Resources::Initialize();
+  if (this->initialization_settings.load_default_resources) {
+    Resources::Initialize();
+  }
   if (this->initialization_settings.enable_runtime_packages) {
     PackageManager::Initialize(this->initialization_settings.package_search_paths,
                                this->initialization_settings.startup_runtime_packages);
@@ -465,6 +471,7 @@ void Application::End() {
 }
 
 void Application::ExecuteEndOfLoopActions() {
+  Jobs::ExecuteMainThreadJobs();
   if (this->end_of_loop_actions_.empty()) {
     return;
   }
@@ -475,6 +482,7 @@ void Application::ExecuteEndOfLoopActions() {
       action();
     }
   }
+  Jobs::ExecuteMainThreadJobs();
 }
 
 void Application::Terminate() {
@@ -484,6 +492,7 @@ void Application::Terminate() {
     (*i)->OnDestroy();
   }
   this->layers_.clear();
+  AssetManager::OnDestroy();
   Jobs::OnDestroy();
   ProjectManager::OnDestroy();
   FileManager::OnDestroy();
@@ -492,7 +501,6 @@ void Application::Terminate() {
   TextureStorage::OnDestroy();
   GeometryStorage::OnDestroy();
 
-  AssetManager::OnDestroy();
   if (has_render_layer) {
     Platform::OnDestroy();
   }

--- a/EvoEngine_SDK/src/AssetManager.cpp
+++ b/EvoEngine_SDK/src/AssetManager.cpp
@@ -1,14 +1,50 @@
 #include "AssetManager.hpp"
 #include "EditorLayer.hpp"
 #include "FileManager.hpp"
+#include "Jobs.hpp"
 #include "ProjectManager.hpp"
 #include "Resources.hpp"
 #include "UnknownPrivateComponent.hpp"
+
+#include <chrono>
+
 using namespace evo_engine;
+
+namespace {
+std::shared_future<std::shared_ptr<IAsset>> MakeReadyAssetFuture(std::shared_ptr<IAsset> asset) {
+  std::promise<std::shared_ptr<IAsset>> promise;
+  promise.set_value(std::move(asset));
+  return promise.get_future().share();
+}
+
+std::string AssetLoadStateName(const AssetManager::AssetLoadState state) {
+  switch (state) {
+    case AssetManager::AssetLoadState::Discovered:
+      return "Discovered";
+    case AssetManager::AssetLoadState::Queued:
+      return "Queued";
+    case AssetManager::AssetLoadState::LoadingCpu:
+      return "Loading CPU payload";
+    case AssetManager::AssetLoadState::WaitingForFinalize:
+      return "Waiting for finalization";
+    case AssetManager::AssetLoadState::Loaded:
+      return "Loaded";
+    case AssetManager::AssetLoadState::Failed:
+      return "Failed";
+    case AssetManager::AssetLoadState::Cancelled:
+      return "Cancelled";
+    default:
+      return "Unknown";
+  }
+}
+}  // namespace
+
+bool AssetManager::AssetLoadSnapshot::Active() const {
+  return queued != 0 || loading_cpu != 0 || waiting_for_finalize != 0;
+}
 
 void AssetManager::Initialize() {
   auto& asset_manager = GetInstance();
-  // Start a thread for asset importing.
   asset_manager.initialized = true;
 }
 void AssetManager::OnInspect(const std::shared_ptr<EditorLayer>& editor_layer) {
@@ -70,12 +106,6 @@ void AssetManager::OnInspect(const std::shared_ptr<EditorLayer>& editor_layer) {
 void AssetManager::OnDestroy() {
   auto& asset_manager = GetInstance();
   Clear();
-  // Notify thread to end.
-
-  // Clear asset loading queue.
-
-  // Clear threads.
-
   asset_manager.initialized = false;
 }
 
@@ -119,8 +149,39 @@ size_t AssetManager::RestoreUnknownAssets() {
 
 void AssetManager::Clear() {
   auto& asset_manager = GetInstance();
-  std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
-  asset_manager.asset_registry_.assets_.clear();
+  struct LoadingFutureSnapshot {
+    std::thread::id owner_thread_id;
+    std::shared_future<std::shared_ptr<IAsset>> future;
+    bool allow_same_thread_partial_access = false;
+  };
+  std::vector<LoadingFutureSnapshot> loading_futures;
+  {
+    std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+    for (const auto& [handle, record] : asset_manager.asset_registry_.loading_assets_) {
+      loading_futures.push_back(
+          {record.owner_thread_id, record.future, record.allow_same_thread_partial_access});
+    }
+  }
+
+  const auto current_thread_id = std::this_thread::get_id();
+  for (const auto& loading_future : loading_futures) {
+    const bool is_same_thread_recursive_load =
+        loading_future.allow_same_thread_partial_access && loading_future.owner_thread_id == current_thread_id;
+    if (loading_future.future.valid() && !is_same_thread_recursive_load) {
+      try {
+        WaitForAssetLoadFutureImpl(loading_future.future);
+      } catch (...) {
+      }
+    }
+  }
+
+  {
+    std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+    asset_manager.asset_registry_.assets_.clear();
+    asset_manager.asset_registry_.loading_assets_.clear();
+    asset_manager.asset_registry_.main_thread_asset_tasks_.clear();
+    asset_manager.asset_registry_.load_snapshot_ = {};
+  }
 }
 
 std::shared_ptr<IAsset> AssetManager::GetAsset(const std::string& type_name, const Handle& asset_handle) {
@@ -146,16 +207,84 @@ void AssetManager::RemoveAssetImpl(const Handle& asset_handle) {
 }
 
 std::shared_ptr<IAsset> AssetManager::GetAssetImpl(const Handle& asset_handle) {
-  // return GetAssetFutureImpl(asset_handle).get();
   if (asset_handle == 0) {
     throw std::invalid_argument("Asset handle is 0!");
   }
+  return WaitForAssetLoadFutureImpl(GetOrCreateAssetLoadFutureImpl(asset_handle, false));
+}
+
+std::shared_future<std::shared_ptr<IAsset>> AssetManager::RequestAssetLoad(const Handle& asset_handle) {
+  return GetOrCreateAssetLoadFutureImpl(asset_handle, true);
+}
+
+std::vector<std::shared_future<std::shared_ptr<IAsset>>> AssetManager::RequestAssetLoads(
+    const std::set<Handle>& asset_handles) {
+  ResetAssetLoadSnapshotImpl(asset_handles.size());
+  std::vector<std::shared_future<std::shared_ptr<IAsset>>> futures;
+  futures.reserve(asset_handles.size());
+  for (const auto& asset_handle : asset_handles) {
+    futures.emplace_back(RequestAssetLoad(asset_handle));
+  }
+  return futures;
+}
+
+AssetManager::AssetLoadSnapshot AssetManager::GetAssetLoadSnapshot() {
+  auto& asset_manager = GetInstance();
+  std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+  auto snapshot = asset_manager.asset_registry_.load_snapshot_;
+  snapshot.queued = 0;
+  snapshot.loading_cpu = 0;
+  snapshot.waiting_for_finalize = 0;
+  for (const auto& [handle, record] : asset_manager.asset_registry_.loading_assets_) {
+    switch (record.state) {
+      case AssetLoadState::Queued:
+        ++snapshot.queued;
+        break;
+      case AssetLoadState::LoadingCpu:
+        ++snapshot.loading_cpu;
+        break;
+      case AssetLoadState::WaitingForFinalize:
+        ++snapshot.waiting_for_finalize;
+        break;
+      default:
+        break;
+    }
+  }
+  return snapshot;
+}
+
+size_t AssetManager::ExecuteMainThreadAssetTasks(const size_t max_task_size) {
+  size_t executed_task_size = 0;
+  while (max_task_size == 0 || executed_task_size < max_task_size) {
+    std::function<void()> task;
+    {
+      auto& asset_manager = GetInstance();
+      std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+      if (asset_manager.asset_registry_.main_thread_asset_tasks_.empty()) {
+        break;
+      }
+      task = std::move(asset_manager.asset_registry_.main_thread_asset_tasks_.front());
+      asset_manager.asset_registry_.main_thread_asset_tasks_.pop_front();
+    }
+    if (task) {
+      task();
+      ++executed_task_size;
+    }
+  }
+  return executed_task_size;
+}
+
+std::shared_ptr<IAsset> AssetManager::LoadAssetImpl(const Handle& asset_handle) {
   auto& asset_manager = GetInstance();
   {
     std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
     if (const auto search = asset_manager.asset_registry_.assets_.find(asset_handle);
         search != asset_manager.asset_registry_.assets_.end() && !search->second.expired()) {
       return search->second.lock();
+    }
+    if (const auto loading_search = asset_manager.asset_registry_.loading_assets_.find(asset_handle);
+        loading_search != asset_manager.asset_registry_.loading_assets_.end()) {
+      loading_search->second.owner_thread_id = std::this_thread::get_id();
     }
   }
   if (const std::shared_ptr<File> file = FileManager::GetFile(asset_handle)) {
@@ -168,6 +297,7 @@ std::shared_ptr<IAsset> AssetManager::GetAssetImpl(const Handle& asset_handle) {
     }
     ret_val->file_record_ = file;
     ret_val->self_ = ret_val;
+    SetLoadingAssetImpl(asset_handle, ret_val, true);
     ret_val->OnCreate();
     if (const auto absolute_path = file->GetAbsolutePath(); std::filesystem::exists(absolute_path)) {
       ret_val->Load();
@@ -185,43 +315,302 @@ std::shared_ptr<IAsset> AssetManager::GetAssetImpl(const Handle& asset_handle) {
   return Resources::TryGetResource<IAsset>(asset_handle);
 }
 
-std::future<std::shared_ptr<IAsset>> AssetManager::GetAssetFutureImpl(const Handle& asset_handle) {
-  std::packaged_task asset_loading_task([asset_handle] {
-    if (asset_handle == 0) {
-      throw std::invalid_argument("Asset handle is 0!");
-    }
-    auto& asset_manager = GetInstance();
-    {
-      std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
-      if (const auto search = asset_manager.asset_registry_.assets_.find(asset_handle);
-          search != asset_manager.asset_registry_.assets_.end() && !search->second.expired()) {
-        return search->second.lock();
+void AssetManager::StartAssetServiceLoadImpl(
+    const Handle& asset_handle, const std::shared_ptr<std::promise<std::shared_ptr<IAsset>>>& promise) {
+  struct AssetServiceLoadContext {
+    std::shared_ptr<IAsset> asset;
+    std::shared_ptr<File> file;
+    std::filesystem::path absolute_path;
+    bool path_exists = false;
+    bool staged = false;
+  };
+
+  auto finish_with_exception = [&]() {
+    promise->set_exception(std::current_exception());
+    UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Failed, "Asset service load failed.");
+    FinishAssetLoadingImpl(asset_handle);
+  };
+
+  try {
+    UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::WaitingForFinalize, "Creating asset object.");
+    auto context_promise = std::make_shared<std::promise<AssetServiceLoadContext>>();
+    const auto context_future = context_promise->get_future().share();
+    ScheduleMainThreadAssetTaskImpl([asset_handle, context_promise]() {
+      try {
+        auto& asset_manager = GetInstance();
+        {
+          std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+          if (const auto search = asset_manager.asset_registry_.assets_.find(asset_handle);
+              search != asset_manager.asset_registry_.assets_.end() && !search->second.expired()) {
+            AssetServiceLoadContext context;
+            context.asset = search->second.lock();
+            context_promise->set_value(std::move(context));
+            return;
+          }
+        }
+
+        AssetServiceLoadContext context;
+        context.file = FileManager::GetFile(asset_handle);
+        if (context.file) {
+          size_t hash_code;
+          context.asset = std::dynamic_pointer_cast<IAsset>(Serialization::ProduceSerializable(
+              Serialization::HasSerializableType(context.file->asset_type_name_) ? context.file->asset_type_name_
+                                                                                 : "UnknownAsset",
+              hash_code, asset_handle));
+          if (!context.asset) {
+            throw std::runtime_error("Failed to create asset instance.");
+          }
+          if (const auto unknown_asset = std::dynamic_pointer_cast<UnknownAsset>(context.asset)) {
+            unknown_asset->SetOriginalTypeName(context.file->asset_type_name_);
+          }
+          context.asset->file_record_ = context.file;
+          context.asset->self_ = context.asset;
+          context.asset->OnCreate();
+          context.absolute_path = context.file->GetAbsolutePath();
+          context.path_exists = std::filesystem::exists(context.absolute_path);
+          context.staged = context.path_exists && context.asset->SupportsStagedLoading(context.absolute_path);
+          SetLoadingAssetImpl(asset_handle, context.asset, !context.staged);
+        }
+        context_promise->set_value(std::move(context));
+      } catch (...) {
+        context_promise->set_exception(std::current_exception());
       }
+    });
+
+    auto context = context_future.get();
+    if (context.asset && !context.file) {
+      promise->set_value(context.asset);
+      UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Loaded, "Asset was already loaded.");
+      FinishAssetLoadingImpl(asset_handle);
+      return;
     }
-    if (const std::shared_ptr<File> file = FileManager::GetFile(asset_handle)) {
-      size_t hash_code;
-      auto ret_val = std::dynamic_pointer_cast<IAsset>(
-          Serialization::ProduceSerializable(file->asset_type_name_, hash_code, asset_handle));
-      ret_val->file_record_ = file;
-      ret_val->self_ = ret_val;
-      ret_val->OnCreate();
-      if (const auto absolute_path = file->GetAbsolutePath(); std::filesystem::exists(absolute_path)) {
-        ret_val->Load();
-      } else {
-        ret_val->Save();
-      }
-      file->asset_ = ret_val;
-      // file->GetThumbnail();
-      {
-        std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
-        asset_manager.asset_registry_.assets_[asset_handle] = ret_val;
-      }
-      return ret_val;
+
+    if (!context.file) {
+      promise->set_value(Resources::TryGetResource<IAsset>(asset_handle));
+      UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Loaded, "Loaded runtime resource.");
+      FinishAssetLoadingImpl(asset_handle);
+      return;
     }
-    return Resources::TryGetResource<IAsset>(asset_handle);
-  });
-  asset_loading_task();
-  return asset_loading_task.get_future();
+
+    if (context.staged) {
+      UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::LoadingCpu, "Loading CPU payload.");
+      auto payload = context.asset->LoadStagedPayloadInternal(context.absolute_path);
+      if (!payload) {
+        throw std::runtime_error("Failed to build staged asset payload.");
+      }
+      UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::WaitingForFinalize, "Waiting for asset finalization.");
+      ScheduleMainThreadAssetTaskImpl([asset_handle, context = std::move(context), promise, payload = std::move(payload)]() {
+        try {
+          if (!context.asset->ApplyStagedPayloadInternal(context.absolute_path, payload)) {
+            throw std::runtime_error("Failed to apply staged asset load payload.");
+          }
+          context.asset->saved_ = true;
+          context.file->asset_ = context.asset;
+          {
+            auto& asset_manager = GetInstance();
+            std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+            asset_manager.asset_registry_.assets_[asset_handle] = context.asset;
+          }
+          promise->set_value(context.asset);
+          UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Loaded, "Asset loaded.");
+        } catch (const std::exception& e) {
+          promise->set_exception(std::current_exception());
+          UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Failed, e.what());
+        } catch (...) {
+          promise->set_exception(std::current_exception());
+          UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Failed, "Unknown asset finalization failure.");
+        }
+        FinishAssetLoadingImpl(asset_handle);
+      });
+      return;
+    }
+
+    UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::WaitingForFinalize, "Waiting for legacy asset load.");
+    ScheduleMainThreadAssetTaskImpl([asset_handle, context = std::move(context), promise]() {
+      try {
+        if (context.path_exists) {
+          context.asset->Load();
+        } else {
+          context.asset->Save();
+        }
+        context.file->asset_ = context.asset;
+        {
+          auto& asset_manager = GetInstance();
+          std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+          asset_manager.asset_registry_.assets_[asset_handle] = context.asset;
+        }
+        promise->set_value(context.asset);
+        UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Loaded, "Asset loaded.");
+      } catch (const std::exception& e) {
+        promise->set_exception(std::current_exception());
+        UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Failed, e.what());
+      } catch (...) {
+        promise->set_exception(std::current_exception());
+        UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Failed, "Unknown asset load failure.");
+      }
+      FinishAssetLoadingImpl(asset_handle);
+    });
+  } catch (...) {
+    finish_with_exception();
+  }
+}
+
+std::shared_ptr<IAsset> AssetManager::WaitForAssetLoadFutureImpl(
+    const std::shared_future<std::shared_ptr<IAsset>>& asset_future) {
+  if (!asset_future.valid()) {
+    return {};
+  }
+  while (asset_future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+    if (Jobs::IsMainThread()) {
+      const auto executed_asset_task_size = ExecuteMainThreadAssetTasks(1);
+      const auto executed_job_size = Jobs::ExecuteMainThreadJobs(1);
+      if (executed_asset_task_size == 0 && executed_job_size == 0) {
+        asset_future.wait_for(std::chrono::milliseconds(1));
+      }
+    } else {
+      asset_future.wait_for(std::chrono::milliseconds(1));
+    }
+  }
+  return asset_future.get();
+}
+
+std::shared_future<std::shared_ptr<IAsset>> AssetManager::GetOrCreateAssetLoadFutureImpl(const Handle& asset_handle,
+                                                                                         const bool async) {
+  if (asset_handle == 0) {
+    throw std::invalid_argument("Asset handle is 0!");
+  }
+
+  auto& asset_manager = GetInstance();
+  std::string asset_name;
+  if (const auto file = FileManager::GetFile(asset_handle)) {
+    asset_name = file->GetAssetsFolderRelativePath().string();
+  }
+  auto promise = std::make_shared<std::promise<std::shared_ptr<IAsset>>>();
+  auto future = promise->get_future().share();
+  {
+    std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+    if (const auto search = asset_manager.asset_registry_.assets_.find(asset_handle);
+        search != asset_manager.asset_registry_.assets_.end() && !search->second.expired()) {
+      return MakeReadyAssetFuture(search->second.lock());
+    }
+    if (const auto loading_search = asset_manager.asset_registry_.loading_assets_.find(asset_handle);
+        loading_search != asset_manager.asset_registry_.loading_assets_.end()) {
+      if (loading_search->second.allow_same_thread_partial_access &&
+          loading_search->second.owner_thread_id == std::this_thread::get_id()) {
+        if (const auto loading_asset = loading_search->second.loading_asset.lock()) {
+          return MakeReadyAssetFuture(loading_asset);
+        }
+        throw std::runtime_error("Recursive asset load requested before asset object was created.");
+      }
+      return loading_search->second.future;
+    }
+
+    AssetRegistry::AssetLoadingRecord record;
+    record.future = future;
+    record.owner_thread_id = async ? std::thread::id() : std::this_thread::get_id();
+    record.async = async;
+    record.allow_same_thread_partial_access = !async;
+    record.state = AssetLoadState::Queued;
+    record.asset_name = asset_name;
+    asset_manager.asset_registry_.loading_assets_[asset_handle] = record;
+
+    auto& snapshot = asset_manager.asset_registry_.load_snapshot_;
+    const auto finished_size = snapshot.completed + snapshot.failed + snapshot.cancelled;
+    if (snapshot.total == 0 || (!snapshot.Active() && finished_size >= snapshot.total)) {
+      snapshot = {};
+      snapshot.total = 1;
+    }
+    snapshot.active_asset_handle = asset_handle;
+    snapshot.active_state = AssetLoadState::Queued;
+    snapshot.active_asset_name = asset_name;
+    snapshot.message = "Queued";
+  }
+
+  try {
+    const auto job_handle = Jobs::RunOnAssetIoThread([asset_handle, promise]() {
+      StartAssetServiceLoadImpl(asset_handle, promise);
+    });
+    if (!job_handle.Valid()) {
+      throw std::runtime_error("Failed to schedule asset service task.");
+    }
+    Jobs::Execute(job_handle);
+  } catch (...) {
+    promise->set_exception(std::current_exception());
+    UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Failed, "Failed to schedule asset service task.");
+    FinishAssetLoadingImpl(asset_handle);
+  }
+  return future;
+}
+
+void AssetManager::ScheduleMainThreadAssetTaskImpl(const std::function<void()>& action) {
+  auto& asset_manager = GetInstance();
+  std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+  asset_manager.asset_registry_.main_thread_asset_tasks_.emplace_back(action);
+}
+
+void AssetManager::ResetAssetLoadSnapshotImpl(const size_t total) {
+  auto& asset_manager = GetInstance();
+  std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+  asset_manager.asset_registry_.load_snapshot_ = {};
+  asset_manager.asset_registry_.load_snapshot_.total = total;
+}
+
+void AssetManager::UpdateAssetLoadStateImpl(const Handle& asset_handle, const AssetLoadState state,
+                                            const std::string& message) {
+  auto& asset_manager = GetInstance();
+  std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+  auto& snapshot = asset_manager.asset_registry_.load_snapshot_;
+  snapshot.active_asset_handle = asset_handle;
+  snapshot.active_state = state;
+  snapshot.message = message.empty() ? AssetLoadStateName(state) : message;
+  if (const auto search = asset_manager.asset_registry_.loading_assets_.find(asset_handle);
+      search != asset_manager.asset_registry_.loading_assets_.end()) {
+    search->second.state = state;
+    search->second.message = snapshot.message;
+    snapshot.active_asset_name = search->second.asset_name;
+  } else {
+    snapshot.active_asset_name.clear();
+  }
+}
+
+void AssetManager::SetLoadingAssetImpl(const Handle& asset_handle, const std::shared_ptr<IAsset>& asset,
+                                       const bool allow_same_thread_partial_access) {
+  auto& asset_manager = GetInstance();
+  std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+  if (const auto search = asset_manager.asset_registry_.loading_assets_.find(asset_handle);
+      search != asset_manager.asset_registry_.loading_assets_.end()) {
+    search->second.loading_asset = asset;
+    search->second.owner_thread_id = std::this_thread::get_id();
+    search->second.allow_same_thread_partial_access = allow_same_thread_partial_access;
+  }
+}
+
+void AssetManager::FinishAssetLoadingImpl(const Handle& asset_handle) {
+  auto& asset_manager = GetInstance();
+  std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+  if (const auto search = asset_manager.asset_registry_.loading_assets_.find(asset_handle);
+      search != asset_manager.asset_registry_.loading_assets_.end()) {
+    auto& snapshot = asset_manager.asset_registry_.load_snapshot_;
+    switch (search->second.state) {
+      case AssetLoadState::Failed:
+        ++snapshot.failed;
+        break;
+      case AssetLoadState::Cancelled:
+        ++snapshot.cancelled;
+        break;
+      default:
+        ++snapshot.completed;
+        break;
+    }
+    if (snapshot.total == 0) {
+      snapshot.total = snapshot.completed + snapshot.failed + snapshot.cancelled;
+    }
+    asset_manager.asset_registry_.loading_assets_.erase(search);
+  }
+}
+
+std::shared_future<std::shared_ptr<IAsset>> AssetManager::GetAssetFutureImpl(const Handle& asset_handle) {
+  return GetOrCreateAssetLoadFutureImpl(asset_handle, true);
 }
 
 std::shared_ptr<IAsset> AssetManager::CreateTemporaryAsset(const std::string& type_name) {

--- a/EvoEngine_SDK/src/AssetManager.cpp
+++ b/EvoEngine_SDK/src/AssetManager.cpp
@@ -158,8 +158,7 @@ void AssetManager::Clear() {
   {
     std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
     for (const auto& [handle, record] : asset_manager.asset_registry_.loading_assets_) {
-      loading_futures.push_back(
-          {record.owner_thread_id, record.future, record.allow_same_thread_partial_access});
+      loading_futures.push_back({record.owner_thread_id, record.future, record.allow_same_thread_partial_access});
     }
   }
 
@@ -315,8 +314,8 @@ std::shared_ptr<IAsset> AssetManager::LoadAssetImpl(const Handle& asset_handle) 
   return Resources::TryGetResource<IAsset>(asset_handle);
 }
 
-void AssetManager::StartAssetServiceLoadImpl(
-    const Handle& asset_handle, const std::shared_ptr<std::promise<std::shared_ptr<IAsset>>>& promise) {
+void AssetManager::StartAssetServiceLoadImpl(const Handle& asset_handle,
+                                             const std::shared_ptr<std::promise<std::shared_ptr<IAsset>>>& promise) {
   struct AssetServiceLoadContext {
     std::shared_ptr<IAsset> asset;
     std::shared_ptr<File> file;
@@ -399,29 +398,30 @@ void AssetManager::StartAssetServiceLoadImpl(
         throw std::runtime_error("Failed to build staged asset payload.");
       }
       UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::WaitingForFinalize, "Waiting for asset finalization.");
-      ScheduleMainThreadAssetTaskImpl([asset_handle, context = std::move(context), promise, payload = std::move(payload)]() {
-        try {
-          if (!context.asset->ApplyStagedPayloadInternal(context.absolute_path, payload)) {
-            throw std::runtime_error("Failed to apply staged asset load payload.");
-          }
-          context.asset->saved_ = true;
-          context.file->asset_ = context.asset;
-          {
-            auto& asset_manager = GetInstance();
-            std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
-            asset_manager.asset_registry_.assets_[asset_handle] = context.asset;
-          }
-          promise->set_value(context.asset);
-          UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Loaded, "Asset loaded.");
-        } catch (const std::exception& e) {
-          promise->set_exception(std::current_exception());
-          UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Failed, e.what());
-        } catch (...) {
-          promise->set_exception(std::current_exception());
-          UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Failed, "Unknown asset finalization failure.");
-        }
-        FinishAssetLoadingImpl(asset_handle);
-      });
+      ScheduleMainThreadAssetTaskImpl(
+          [asset_handle, context = std::move(context), promise, payload = std::move(payload)]() {
+            try {
+              if (!context.asset->ApplyStagedPayloadInternal(context.absolute_path, payload)) {
+                throw std::runtime_error("Failed to apply staged asset load payload.");
+              }
+              context.asset->saved_ = true;
+              context.file->asset_ = context.asset;
+              {
+                auto& asset_manager = GetInstance();
+                std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
+                asset_manager.asset_registry_.assets_[asset_handle] = context.asset;
+              }
+              promise->set_value(context.asset);
+              UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Loaded, "Asset loaded.");
+            } catch (const std::exception& e) {
+              promise->set_exception(std::current_exception());
+              UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Failed, e.what());
+            } catch (...) {
+              promise->set_exception(std::current_exception());
+              UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::Failed, "Unknown asset finalization failure.");
+            }
+            FinishAssetLoadingImpl(asset_handle);
+          });
       return;
     }
 

--- a/EvoEngine_SDK/src/FileManager.cpp
+++ b/EvoEngine_SDK/src/FileManager.cpp
@@ -126,13 +126,6 @@ void File::Load(const std::filesystem::path& path) {
 }
 
 std::shared_ptr<Texture2D> File::GetThumbnail() {
-  // TODO: This should be handled by GetAssetFuture, so it doesn't block the master thread.
-  if (!thumbnail_ && asset_type_name_ != "Binary" && asset_type_name_ != "Scene" && asset_type_name_ != "Prefab" &&
-      asset_type_name_ != "Mesh") {
-    if (const auto asset = AssetManager::GetAssetImpl(asset_handle_)) {
-      thumbnail_ = asset->GenerateThumbnailTexture();
-    }
-  }
   if (!thumbnail_) {
     if (const auto icon = EditorLayer::FindIcon(asset_type_name_)) {
       thumbnail_ = icon;

--- a/EvoEngine_SDK/src/GraphicsResources.cpp
+++ b/EvoEngine_SDK/src/GraphicsResources.cpp
@@ -1035,10 +1035,14 @@ void CommandBuffer::End() {
   status_ = CommandBufferStatus::Recorded;
 }
 
-void CommandBuffer::Record(const std::function<void(VkCommandBuffer vk_command_buffer)>& commands) {
+bool CommandBuffer::Record(const std::function<void(VkCommandBuffer vk_command_buffer)>& commands) {
   Begin();
+  if (status_ != CommandBufferStatus::Recording) {
+    return false;
+  }
   commands(vk_command_buffer_);
   End();
+  return status_ == CommandBufferStatus::Recorded;
 }
 
 void CommandBuffer::Reset() {

--- a/EvoEngine_SDK/src/IAsset.cpp
+++ b/EvoEngine_SDK/src/IAsset.cpp
@@ -77,7 +77,7 @@ bool IAsset::SupportsStagedLoading() const {
   return false;
 }
 
-bool IAsset::SupportsStagedLoading(const std::filesystem::path&) const {
+bool IAsset::SupportsStagedLoading(const std::filesystem::path &) const {
   return SupportsStagedLoading();
 }
 

--- a/EvoEngine_SDK/src/IAsset.cpp
+++ b/EvoEngine_SDK/src/IAsset.cpp
@@ -3,6 +3,14 @@
 #include "EditorLayer.hpp"
 #include "ProjectManager.hpp"
 using namespace evo_engine;
+
+namespace {
+class YamlStagedLoadPayload final : public StagedAssetLoadPayload {
+ public:
+  YAML::Node node;
+};
+}  // namespace
+
 bool IAsset::Save() {
   if (IsTemporary())
     return false;
@@ -60,6 +68,47 @@ bool IAsset::LoadInternal(const std::filesystem::path &path) {
     Deserialize(in);
   } catch (const std::exception &e) {
     EVOENGINE_ERROR("Failed to load: " + std::string(e.what()))
+    return false;
+  }
+  return true;
+}
+
+bool IAsset::SupportsStagedLoading() const {
+  return false;
+}
+
+bool IAsset::SupportsStagedLoading(const std::filesystem::path&) const {
+  return SupportsStagedLoading();
+}
+
+std::shared_ptr<StagedAssetLoadPayload> IAsset::LoadStagedPayloadInternal(const std::filesystem::path &path) const {
+  if (!std::filesystem::exists(path)) {
+    EVOENGINE_ERROR("Not exist!")
+    return {};
+  }
+  try {
+    const std::ifstream stream(path.string());
+    std::stringstream string_stream;
+    string_stream << stream.rdbuf();
+    auto payload = std::make_shared<YamlStagedLoadPayload>();
+    payload->node = YAML::Load(string_stream.str());
+    return payload;
+  } catch (const std::exception &e) {
+    EVOENGINE_ERROR("Failed to load staged payload: " + std::string(e.what()))
+    return {};
+  }
+}
+
+bool IAsset::ApplyStagedPayloadInternal(const std::filesystem::path &,
+                                        const std::shared_ptr<StagedAssetLoadPayload> &payload) {
+  const auto yaml_payload = std::dynamic_pointer_cast<YamlStagedLoadPayload>(payload);
+  if (!yaml_payload) {
+    return false;
+  }
+  try {
+    Deserialize(yaml_payload->node);
+  } catch (const std::exception &e) {
+    EVOENGINE_ERROR("Failed to apply staged payload: " + std::string(e.what()))
     return false;
   }
   return true;

--- a/EvoEngine_SDK/src/JobSystem.cpp
+++ b/EvoEngine_SDK/src/JobSystem.cpp
@@ -1,283 +1,41 @@
 #include "JobSystem.hpp"
 
-#include "Console.hpp"
-
 using namespace evo_engine;
 
-int JobHandle::GetIndex() const {
-  return index_;
-}
-
-bool JobHandle::Valid() const {
-  return index_ >= 0;
-}
-
-void JobSystem::JobSystemSemaphore::Reset(const size_t availability) {
-  availability_ = availability;
-}
-
-void JobSystem::JobSystemSemaphore::Acquire() {
-  std::unique_lock lk(update_mutex_);
-  cv_.wait(lk, [this]() {
-    return availability_ > 0;
-  });
-  availability_--;
-}
-
-void JobSystem::JobSystemSemaphore::Release() {
-  std::unique_lock lk(update_mutex_);
-  availability_++;
-  cv_.notify_one();
-}
-
-inline void JobSystem::JobPool::Push(std::pair<JobHandle, std::function<void()>>&& job) {
-  std::unique_lock lock(pool_mutex_);
-  job_queue_.push(std::forward<std::pair<JobHandle, std::function<void()>>>(job));
-}
-
-inline bool JobSystem::JobPool::Pop(std::pair<JobHandle, std::function<void()>>& job) {
-  std::unique_lock lock(pool_mutex_);
-  if (job_queue_.empty())
-    return false;
-  job = std::forward<std::pair<JobHandle, std::function<void()>>>(job_queue_.front());
-  job_queue_.pop();
-  return true;
-}
-
-inline bool JobSystem::JobPool::Empty() {
-  std::unique_lock lock(pool_mutex_);
-  return job_queue_.empty();
-}
-
-void JobSystem::CheckJobAvailableHelper(const JobHandle& job_handle) {
-  const auto& job = jobs_.at(job_handle.GetIndex());
-  bool job_ready_to_run = job->wake;
-  if (job_ready_to_run) {
-    for (const auto& child_handle : job->children) {
-      if (!jobs_[child_handle.index_]->finished) {
-        job_ready_to_run = false;
-        break;
-      }
-    }
-  }
-  if (job_ready_to_run) {
-    available_job_pool_.Push(std::make_pair(job_handle, std::forward<std::function<void()>>(job->task)));
-    std::unique_lock lock(this->job_availability_mutex_);
-    job_available_condition_.notify_one();
-  }
-}
-void JobSystem::ReportFinish(const JobHandle& job_handle) {
-  std::lock_guard job_management_mutex(job_management_mutex_);
-  const auto job_index = job_handle.GetIndex();
-  const auto& job = jobs_[job_index];
-  job->finished = true;
-  job->finished_semaphore.Release();
-  for (const auto& parent : job->parents) {
-    CheckJobAvailableHelper(parent);
-  }
-}
-
-void JobSystem::InitializeWorker(const size_t worker_index) {
-  std::shared_ptr flag(flags_[worker_index]);  // a copy of the shared ptr to the flag
-  auto thread_func = [this, flag /* a copy of the shared ptr to the flag */]() {
-    std::atomic<bool>& flag_ptr = *flag;
-    std::pair<JobHandle, std::function<void()>> task;
-    bool is_pop = available_job_pool_.Pop(task);
-    while (true) {
-      while (is_pop) {  // if there is anything in the queue
-        task.second();
-        ReportFinish(task.first);
-        // if (flagPtr)
-        //	return; // the thread is wanted to stop, return even if the queue is not empty yet
-        is_pop = available_job_pool_.Pop(task);
-        if (!is_pop)
-          task = {};
-      }
-      // the queue is empty here, wait for the next command
-      std::unique_lock lock(job_availability_mutex_);
-      ++idle_thread_amount_;
-      job_available_condition_.wait(lock, [this, &is_pop, &task, &flag_ptr]() {
-        is_pop = available_job_pool_.Pop(task);
-        return is_pop || is_done_ || flag_ptr;
-      });
-      --idle_thread_amount_;
-      if (!is_pop)
-        return;  // if the queue is empty and is_done_ == true or *flag then return
-    }
-  };
-  workers_[worker_index].reset(new std::thread(thread_func));  // compiler may not support std::make_unique()
-}
-
-bool JobSystem::MainThreadCheck() const {
-  if (main_thread_id_ == std::this_thread::get_id()) {
-    return true;
-  }
-  EVOENGINE_ERROR("Jobs: Not on main thread!!");
-  return false;
-}
-
-void JobSystem::CollectDescendantsHelper(std::vector<JobHandle>& jobs, const JobHandle& walker) {
-  jobs.emplace_back(walker);
-  for (const auto& i : jobs_.at(walker.GetIndex())->children) {
-    CollectDescendantsHelper(jobs, i);
-  }
-}
-
-JobHandle JobSystem::PushJob(const std::vector<JobHandle>& dependencies, std::function<void()>&& func) {
-  if (!MainThreadCheck())
-    return {};
-  std::lock_guard job_management_mutex(job_management_mutex_);
-  std::vector<JobHandle> filtered_dependencies;
-  for (const auto& dependency : dependencies) {
-    if (!dependency.Valid())
-      continue;
-    filtered_dependencies.emplace_back(dependency);
-  }
-  std::vector<JobHandle> descendants;
-  for (const auto& dependency : filtered_dependencies) {
-    CollectDescendantsHelper(descendants, dependency);
-  }
-  JobHandle new_job_handle;
-  if (!recycled_jobs_.empty()) {
-    new_job_handle = recycled_jobs_.front();
-    recycled_jobs_.pop();
-  } else {
-    new_job_handle.index_ = jobs_.size();
-    jobs_.emplace_back(std::make_shared<Job>());
-    jobs_.back()->job_handle = new_job_handle;
-  }
-  const auto& new_job = jobs_.at(new_job_handle.GetIndex());
-  new_job->task = std::forward<std::function<void()>>(func);
-  new_job->wake = false;
-  new_job->children = filtered_dependencies;
-  new_job->recycled = false;
-  new_job->finished = false;
-
-  for (const auto& child_handle : filtered_dependencies) {
-    if (!child_handle.Valid())
-      continue;
-    const auto& child_job = jobs_.at(child_handle.GetIndex());
-    child_job->parents.emplace_back(new_job_handle);
-  }
-  return new_job_handle;
-}
-
-void JobSystem::ExecuteJob(const JobHandle& job_handle) {
-  if (!MainThreadCheck())
-    return;
-  if (!job_handle.Valid())
-    return;
-  std::lock_guard job_management_mutex(job_management_mutex_);
-  std::vector<JobHandle> job_handles;
-  CollectDescendantsHelper(job_handles, job_handle);
-  for (const auto& walker : job_handles) {
-    if (const auto& job = jobs_[walker.GetIndex()]; !job->wake) {
-      job->wake = true;
-      CheckJobAvailableHelper(walker);
-    }
-  }
-}
-
-void JobSystem::Wait(const JobHandle& job_handle) {
-  if (!MainThreadCheck())
-    return;
-  if (!job_handle.Valid())
-    return;
-  const auto& job = jobs_[job_handle.GetIndex()];
-  if (!job->parents.empty()) {
-    EVOENGINE_ERROR("Cannot wait job that's not root!");
-    return;
-  }
-  std::vector<JobHandle> job_handles;
-  CollectDescendantsHelper(job_handles, job_handle);
-  for (const auto& walker : job_handles) {
-    const auto& job = jobs_[walker.GetIndex()];
-    if (!job->recycled) {
-      job->finished_semaphore.Acquire();
-      recycled_jobs_.emplace(walker);
-      job->recycled = true;
-      job->parents.clear();
-      job->children.clear();
-    }
-  }
-}
-
 void JobSystem::StopAllWorkers() {
-  if (!MainThreadCheck())
-    return;
-  if (is_done_)
-    return;
-  is_done_ = true;  // give the waiting threads a command to finish
-  {
-    std::unique_lock lock(this->job_availability_mutex_);
-    job_available_condition_.notify_all();  // stop all waiting threads
-  }
-  for (const auto& worker : workers_) {  // wait for the computing threads to finish
-    if (worker->joinable())
-      worker->join();
-  }
-  // if there were no threads in the pool but some functors in the queue, the functors are not deleted by the
-  // threads therefore delete them here
-  workers_.clear();
-  flags_.clear();
-  idle_thread_amount_ = 0;
-  is_done_ = false;
+  Shutdown();
 }
 
 size_t JobSystem::IdleWorkerSize() const {
-  return idle_thread_amount_;
-}
-
-JobSystem::JobSystem() {
-  main_thread_id_ = std::this_thread::get_id();
-  ResizeWorker(1);
+  const auto stats = GetStats();
+  return stats.worker_thread_size > stats.running_task_size ? stats.worker_thread_size - stats.running_task_size : 0;
 }
 
 void JobSystem::OnDestroy() {
-  StopAllWorkers();
-}
-
-JobSystem::~JobSystem() {
-  OnDestroy();
+  Shutdown();
 }
 
 void JobSystem::ResizeWorker(const size_t worker_size) {
-  if (!MainThreadCheck())
-    return;
-  if (worker_size < 1) {
-    EVOENGINE_ERROR("Worker size is zero!");
-    return;
-  }
-
-  if (!is_done_) {
-    if (const auto old_n_threads = workers_.size();
-        old_n_threads <= worker_size) {  // if the number of threads is increased
-      workers_.resize(worker_size);
-      flags_.resize(worker_size);
-
-      for (size_t i = old_n_threads; i < worker_size; ++i) {
-        flags_[i] = std::make_shared<std::atomic<bool>>(false);
-        InitializeWorker(i);
-      }
-    } else {  // the number of threads is decreased
-      for (size_t i = old_n_threads - 1; i >= worker_size; --i) {
-        *flags_[i] = true;  // this thread will finish
-        workers_[i]->detach();
-      }
-      {
-        // stop the detached threads that were waiting
-        std::unique_lock lock(job_availability_mutex_);
-        job_available_condition_.notify_all();
-      }
-      workers_.resize(worker_size);  // safe to delete because the threads are detached
-      flags_.resize(worker_size);    // safe to delete because the threads have copies of shared_ptr of the
-                                     // flags, not originals
-    }
-  }
+  TaskRuntime::ResizeWorker(worker_size);
 }
 
 size_t JobSystem::GetWorkerSize() const {
-  if (!MainThreadCheck())
-    return 0;
-  return workers_.size();
+  return TaskRuntime::GetWorkerSize();
+}
+
+JobHandle JobSystem::PushJob(const std::vector<JobHandle>& dependencies, std::function<void()>&& func) {
+  return Schedule(dependencies, std::move(func));
+}
+
+JobHandle JobSystem::PushJob(const std::vector<JobHandle>& dependencies, const JobOptions& options,
+                             std::function<void()>&& func) {
+  return Schedule(dependencies, options, std::move(func));
+}
+
+void JobSystem::ExecuteJob(const JobHandle& job_handle) {
+  Execute(job_handle);
+}
+
+void JobSystem::Wait(const JobHandle& job_handle) {
+  TaskRuntime::Wait(job_handle);
 }

--- a/EvoEngine_SDK/src/Jobs.cpp
+++ b/EvoEngine_SDK/src/Jobs.cpp
@@ -28,13 +28,39 @@ size_t Jobs::GetWorkerSize() {
 
 void Jobs::Initialize(const size_t worker_size) {
   auto& jobs = GetInstance();
-  jobs.job_system_.ResizeWorker(worker_size);
+  JobRuntimeSettings settings;
+  settings.worker_thread_size = std::max<size_t>(1, worker_size);
+  settings.asset_io_thread_size = 1;
+  settings.render_thread_size = 1;
+  settings.background_thread_size = 1;
+  jobs.job_system_.Initialize(settings);
+}
+
+JobRuntimeStats Jobs::GetRuntimeStats() {
+  const auto& jobs = GetInstance();
+  return jobs.job_system_.GetStats();
+}
+
+bool Jobs::IsMainThread() {
+  const auto& jobs = GetInstance();
+  return jobs.job_system_.IsMainThread();
+}
+
+bool Jobs::IsExecutorThread(const JobExecutorType executor) {
+  const auto& jobs = GetInstance();
+  return jobs.job_system_.IsExecutorThread(executor);
+}
+
+size_t Jobs::ExecuteMainThreadJobs(const size_t max_task_size) {
+  auto& jobs = GetInstance();
+  return jobs.job_system_.RunReadyMainThreadTasks(max_task_size);
 }
 
 void Jobs::RunParallelFor(const size_t size, const std::function<void(size_t i)>& func, size_t worker_size) {
   auto& jobs = GetInstance();
   if (worker_size == 0)
     worker_size = GetWorkerSize();
+  worker_size = std::max<size_t>(1, worker_size);
   const auto thread_load = size / worker_size;
   const auto load_reminder = size % worker_size;
   std::vector<JobHandle> job_handles;
@@ -57,6 +83,7 @@ void Jobs::RunParallelFor(const size_t size, const std::function<void(size_t, si
   auto& jobs = GetInstance();
   if (worker_size == 0)
     worker_size = GetWorkerSize();
+  worker_size = std::max<size_t>(1, worker_size);
   const auto thread_load = size / worker_size;
   const auto load_reminder = size % worker_size;
   std::vector<JobHandle> job_handles;
@@ -79,6 +106,7 @@ JobHandle Jobs::ScheduleParallelFor(const size_t size, const std::function<void(
   auto& jobs = GetInstance();
   if (worker_size == 0)
     worker_size = GetWorkerSize();
+  worker_size = std::max<size_t>(1, worker_size);
   const auto thread_load = size / worker_size;
   const auto load_reminder = size % worker_size;
   std::vector<JobHandle> job_handles;
@@ -102,6 +130,7 @@ JobHandle Jobs::ScheduleParallelFor(const size_t size, const std::function<void(
   auto& jobs = GetInstance();
   if (worker_size == 0)
     worker_size = GetWorkerSize();
+  worker_size = std::max<size_t>(1, worker_size);
   const auto thread_load = size / worker_size;
   const auto load_reminder = size % worker_size;
   std::vector<JobHandle> job_handles;
@@ -125,6 +154,7 @@ void Jobs::RunParallelFor(const std::vector<JobHandle>& dependencies, const size
   auto& jobs = GetInstance();
   if (worker_size == 0)
     worker_size = GetWorkerSize();
+  worker_size = std::max<size_t>(1, worker_size);
   const auto thread_load = size / worker_size;
   const auto load_reminder = size % worker_size;
   std::vector<JobHandle> job_handles;
@@ -148,6 +178,7 @@ void Jobs::RunParallelFor(const std::vector<JobHandle>& dependencies, const size
   auto& jobs = GetInstance();
   if (worker_size == 0)
     worker_size = GetWorkerSize();
+  worker_size = std::max<size_t>(1, worker_size);
   const auto thread_load = size / worker_size;
   const auto load_reminder = size % worker_size;
   std::vector<JobHandle> job_handles;
@@ -171,6 +202,7 @@ JobHandle Jobs::ScheduleParallelFor(const std::vector<JobHandle>& dependencies, 
   auto& jobs = GetInstance();
   if (worker_size == 0)
     worker_size = GetWorkerSize();
+  worker_size = std::max<size_t>(1, worker_size);
   const auto thread_load = size / worker_size;
   const auto load_reminder = size % worker_size;
   std::vector<JobHandle> job_handles;
@@ -194,6 +226,7 @@ JobHandle Jobs::ScheduleParallelFor(const std::vector<JobHandle>& dependencies, 
   auto& jobs = GetInstance();
   if (worker_size == 0)
     worker_size = GetWorkerSize();
+  worker_size = std::max<size_t>(1, worker_size);
   const auto thread_load = size / worker_size;
   const auto load_reminder = size % worker_size;
   std::vector<JobHandle> job_handles;
@@ -217,15 +250,62 @@ JobHandle Jobs::Run(const std::vector<JobHandle>& dependencies, const std::funct
   return jobs.job_system_.PushJob(dependencies, BindApplicationContext(std::function<void()>(func)));
 }
 
+JobHandle Jobs::Run(const std::vector<JobHandle>& dependencies, const JobOptions& options,
+                    const std::function<void()>& func) {
+  auto& jobs = GetInstance();
+  return jobs.job_system_.PushJob(dependencies, options, BindApplicationContext(std::function<void()>(func)));
+}
+
 JobHandle Jobs::Run(const std::function<void()>& func) {
   auto& jobs = GetInstance();
   return jobs.job_system_.PushJob({}, BindApplicationContext(std::function<void()>(func)));
+}
+
+JobHandle Jobs::Run(const JobOptions& options, const std::function<void()>& func) {
+  auto& jobs = GetInstance();
+  return jobs.job_system_.PushJob({}, options, BindApplicationContext(std::function<void()>(func)));
+}
+
+JobHandle Jobs::RunOnMainThread(const std::function<void()>& func) {
+  JobOptions options;
+  options.executor = JobExecutorType::MainThread;
+  options.affinity = JobThreadAffinity::MainThread;
+  options.debug_name = "Jobs::RunOnMainThread";
+  return Run(options, func);
+}
+
+JobHandle Jobs::RunOnAssetIoThread(const std::function<void()>& func) {
+  JobOptions options;
+  options.executor = JobExecutorType::AssetIo;
+  options.affinity = JobThreadAffinity::AssetIo;
+  options.debug_name = "Jobs::RunOnAssetIoThread";
+  return Run(options, func);
+}
+
+JobHandle Jobs::RunOnRenderThread(const std::function<void()>& func) {
+  JobOptions options;
+  options.executor = JobExecutorType::Render;
+  options.affinity = JobThreadAffinity::Render;
+  options.debug_name = "Jobs::RunOnRenderThread";
+  return Run(options, func);
+}
+
+JobHandle Jobs::RunOnBackgroundThread(const std::function<void()>& func) {
+  JobOptions options;
+  options.executor = JobExecutorType::Background;
+  options.affinity = JobThreadAffinity::Background;
+  options.debug_name = "Jobs::RunOnBackgroundThread";
+  return Run(options, func);
 }
 
 JobHandle Jobs::Combine(const std::vector<JobHandle>& dependencies) {
   auto& jobs = GetInstance();
   return jobs.job_system_.PushJob(dependencies, BindApplicationContext([]() {
                                   }));
+}
+
+JobHandle Jobs::Combine(const JobGroup& job_group) {
+  return Combine(job_group.GetHandles());
 }
 
 void Jobs::Execute(const JobHandle& job_handle) {

--- a/EvoEngine_SDK/src/Json.cpp
+++ b/EvoEngine_SDK/src/Json.cpp
@@ -1,6 +1,14 @@
 #include "Json.hpp"
+#include "Console.hpp"
 
 using namespace evo_engine;
+
+namespace {
+class JsonStagedLoadPayload final : public StagedAssetLoadPayload {
+ public:
+  nlohmann::json json;
+};
+}  // namespace
 
 bool Json::SaveInternal(const std::filesystem::path& path) const {
   std::ofstream o(path);
@@ -11,6 +19,32 @@ bool Json::SaveInternal(const std::filesystem::path& path) const {
 bool Json::LoadInternal(const std::filesystem::path& path) {
   std::ifstream ifs(path);
   m_json = nlohmann::json::parse(ifs);
+  return true;
+}
+
+bool Json::SupportsStagedLoading() const {
+  return true;
+}
+
+std::shared_ptr<StagedAssetLoadPayload> Json::LoadStagedPayloadInternal(const std::filesystem::path& path) const {
+  try {
+    std::ifstream ifs(path);
+    auto payload = std::make_shared<JsonStagedLoadPayload>();
+    payload->json = nlohmann::json::parse(ifs);
+    return payload;
+  } catch (const std::exception& e) {
+    EVOENGINE_ERROR("Failed to load staged JSON payload: " + std::string(e.what()))
+    return {};
+  }
+}
+
+bool Json::ApplyStagedPayloadInternal(const std::filesystem::path&,
+                                      const std::shared_ptr<StagedAssetLoadPayload>& payload) {
+  const auto json_payload = std::dynamic_pointer_cast<JsonStagedLoadPayload>(payload);
+  if (!json_payload) {
+    return false;
+  }
+  m_json = std::move(json_payload->json);
   return true;
 }
 

--- a/EvoEngine_SDK/src/Platform.cpp
+++ b/EvoEngine_SDK/src/Platform.cpp
@@ -19,6 +19,26 @@
 
 using namespace evo_engine;
 
+namespace {
+thread_local bool immediate_submit_in_progress = false;
+
+class ImmediateSubmitProgressScope {
+  bool& flag_;
+
+ public:
+  explicit ImmediateSubmitProgressScope(bool& flag) : flag_(flag) {
+    flag_ = true;
+  }
+
+  ~ImmediateSubmitProgressScope() {
+    flag_ = false;
+  }
+
+  ImmediateSubmitProgressScope(const ImmediateSubmitProgressScope&) = delete;
+  ImmediateSubmitProgressScope& operator=(const ImmediateSubmitProgressScope&) = delete;
+};
+}
+
 const Platform::Capabilities& Platform::GetCapabilities() const {
   return capabilities_;
 }
@@ -347,8 +367,9 @@ void Platform::RecordCommandsMainQueue(const std::function<void(VkCommandBuffer 
     graphics.command_buffer_pool_[current_frame_index].emplace_back(std::make_shared<CommandBuffer>());
   }
   const auto& vk_command_buffer = graphics.command_buffer_pool_[current_frame_index][vk_command_buffer_index];
-  vk_command_buffer->Record(action);
-  graphics.used_command_buffer_size_++;
+  if (vk_command_buffer->Record(action)) {
+    graphics.used_command_buffer_size_++;
+  }
 }
 
 void Platform::RecordRenderCommands(const VkRenderingInfo& rendering_info, const VkCommandBuffer vk_command_buffer,
@@ -451,8 +472,15 @@ size_t Platform::GetMaxShadowCascadeAmount() {
 }
 
 void Platform::ImmediateSubmit(const std::function<void(VkCommandBuffer vk_command_buffer)>& action) {
-  const auto& graphics = GetInstance();
-  graphics.immediate_submit_command_buffer->Record(action);
+  if (immediate_submit_in_progress) {
+    throw std::runtime_error("Nested immediate submit is not supported.");
+  }
+  auto& graphics = GetInstance();
+  std::lock_guard lock(graphics.immediate_submit_mutex_);
+  const ImmediateSubmitProgressScope immediate_submit_progress_scope(immediate_submit_in_progress);
+  if (!graphics.immediate_submit_command_buffer->Record(action)) {
+    throw std::runtime_error("Failed to record immediate submit command buffer.");
+  }
 
   VkSubmitInfo submit_info{};
   submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;

--- a/EvoEngine_SDK/src/Platform.cpp
+++ b/EvoEngine_SDK/src/Platform.cpp
@@ -37,7 +37,7 @@ class ImmediateSubmitProgressScope {
   ImmediateSubmitProgressScope(const ImmediateSubmitProgressScope&) = delete;
   ImmediateSubmitProgressScope& operator=(const ImmediateSubmitProgressScope&) = delete;
 };
-}
+}  // namespace
 
 const Platform::Capabilities& Platform::GetCapabilities() const {
   return capabilities_;

--- a/EvoEngine_SDK/src/PointCloud.cpp
+++ b/EvoEngine_SDK/src/PointCloud.cpp
@@ -15,12 +15,75 @@
 using namespace evo_engine;
 using namespace tinyply;
 
+namespace {
+class PointCloudStagedLoadPayload final : public StagedAssetLoadPayload {
+ public:
+  bool yaml = false;
+  YAML::Node yaml_node;
+  std::vector<glm::dvec3> positions;
+  std::vector<glm::dvec3> normals;
+  std::vector<glm::vec4> colors;
+};
+}  // namespace
+
 bool PointCloud::LoadInternal(const std::filesystem::path& path) {
   if (path.extension() == ".ply") {
     return LoadPly({}, path);
   }
 
   return IAsset::LoadInternal(path);
+}
+
+bool PointCloud::SupportsStagedLoading(const std::filesystem::path& path) const {
+  return path.extension() == ".evepointcloud" || path.extension() == ".ply";
+}
+
+std::shared_ptr<StagedAssetLoadPayload> PointCloud::LoadStagedPayloadInternal(const std::filesystem::path& path) const {
+  try {
+    auto payload = std::make_shared<PointCloudStagedLoadPayload>();
+    if (path.extension() == ".ply") {
+      PointCloud loaded_point_cloud;
+      if (!loaded_point_cloud.LoadPly({}, path)) {
+        return {};
+      }
+      payload->positions = std::move(loaded_point_cloud.positions);
+      payload->normals = std::move(loaded_point_cloud.normals);
+      payload->colors = std::move(loaded_point_cloud.colors);
+      return payload;
+    }
+
+    const std::ifstream stream(path.string());
+    std::stringstream string_stream;
+    string_stream << stream.rdbuf();
+    payload->yaml = true;
+    payload->yaml_node = YAML::Load(string_stream.str());
+    return payload;
+  } catch (const std::exception& e) {
+    EVOENGINE_ERROR("Failed to load staged point cloud payload: " + std::string(e.what()))
+    return {};
+  }
+}
+
+bool PointCloud::ApplyStagedPayloadInternal(const std::filesystem::path&,
+                                            const std::shared_ptr<StagedAssetLoadPayload>& payload) {
+  const auto point_cloud_payload = std::dynamic_pointer_cast<PointCloudStagedLoadPayload>(payload);
+  if (!point_cloud_payload) {
+    return false;
+  }
+  try {
+    if (point_cloud_payload->yaml) {
+      Deserialize(point_cloud_payload->yaml_node);
+      return true;
+    }
+    positions = std::move(point_cloud_payload->positions);
+    normals = std::move(point_cloud_payload->normals);
+    colors = std::move(point_cloud_payload->colors);
+    RecalculateBoundingBox();
+  } catch (const std::exception& e) {
+    EVOENGINE_ERROR("Failed to apply staged point cloud payload: " + std::string(e.what()))
+    return false;
+  }
+  return true;
 }
 
 bool PointCloud::SaveInternal(const std::filesystem::path& path) const {

--- a/EvoEngine_SDK/src/Prefab.cpp
+++ b/EvoEngine_SDK/src/Prefab.cpp
@@ -822,6 +822,59 @@ bool Prefab::LoadInternal(const std::filesystem::path& path) {
   }
   return LoadModelInternal(path);
 }
+
+namespace {
+class PrefabStagedLoadPayload final : public StagedAssetLoadPayload {
+ public:
+  YAML::Node node;
+};
+}  // namespace
+
+bool Prefab::SupportsStagedLoading(const std::filesystem::path& path) const {
+  return path.extension() == ".eveprefab";
+}
+
+std::shared_ptr<StagedAssetLoadPayload> Prefab::LoadStagedPayloadInternal(const std::filesystem::path& path) const {
+  try {
+    const std::ifstream stream(path.string());
+    std::stringstream string_stream;
+    string_stream << stream.rdbuf();
+    auto payload = std::make_shared<PrefabStagedLoadPayload>();
+    payload->node = YAML::Load(string_stream.str());
+    return payload;
+  } catch (const std::exception& e) {
+    EVOENGINE_ERROR("Failed to load staged prefab payload: " + std::string(e.what()))
+    return {};
+  }
+}
+
+bool Prefab::ApplyStagedPayloadInternal(const std::filesystem::path&,
+                                        const std::shared_ptr<StagedAssetLoadPayload>& payload) {
+  const auto prefab_payload = std::dynamic_pointer_cast<PrefabStagedLoadPayload>(payload);
+  if (!prefab_payload) {
+    return false;
+  }
+  try {
+    const auto& in = prefab_payload->node;
+    if (const auto& in_local_assets = in["LocalAssets"]) {
+      std::vector<std::shared_ptr<IAsset>> local_assets;
+      for (const auto& i : in_local_assets) {
+        Handle handle = i["Handle"].as<uint64_t>();
+        local_assets.push_back(AssetManager::CreateTemporaryAssetImpl(i["TypeName"].as<std::string>(), handle));
+      }
+      int index = 0;
+      for (const auto& i : in_local_assets) {
+        local_assets[index++]->Deserialize(i);
+      }
+    }
+    Deserialize(in);
+  } catch (const std::exception& e) {
+    EVOENGINE_ERROR("Failed to apply staged prefab payload: " + std::string(e.what()))
+    return false;
+  }
+  return true;
+}
+
 bool Prefab::LoadModelInternal(const std::filesystem::path& path, bool optimize, unsigned int flags) {
   flags = flags | aiProcess_Triangulate;
   if (optimize) {

--- a/EvoEngine_SDK/src/ProjectManager.cpp
+++ b/EvoEngine_SDK/src/ProjectManager.cpp
@@ -9,6 +9,9 @@
 #  include "shellapi.h"
 #endif
 
+#include <algorithm>
+#include <vector>
+
 using namespace evo_engine;
 
 std::weak_ptr<Folder> ProjectManager::GetOrCreateFolder(const std::filesystem::path& assets_relative_path) {
@@ -95,18 +98,37 @@ void ProjectManager::PreUpdate() {
 
   if (project_manager.scan_assets_pending) {
     ScanAssets();
-  } else if (!project_manager.pending_assets.empty()) {
-    const auto handle = *project_manager.pending_assets.begin();
-    project_manager.pending_assets.erase(handle);
-    AssetManager::GetAssetImpl(handle);
-  } else if (!project_manager.new_project_path_.empty()) {
-    SetupDefaultScene();
+    return;
   }
 
-  if (project_manager.pending_assets.empty()) {
-    project_manager.pending_asset_size = 0;
-  } else {
+  if (!project_manager.pending_assets.empty()) {
+    LoadAllPendingAssets();
   }
+
+  if (project_manager.project_asset_load_dispatched) {
+    const auto snapshot = AssetManager::GetAssetLoadSnapshot();
+    if (snapshot.Active()) {
+      return;
+    }
+    project_manager.project_asset_load_dispatched = false;
+    project_manager.pending_asset_size = 0;
+  }
+
+  if (!project_manager.new_project_path_.empty()) {
+    if (ApplicationContext::Get().GetApplicationInfo().load_project_start_scene) {
+      SetupDefaultScene();
+    } else {
+      project_manager.new_project_path_ = "";
+    }
+  }
+}
+
+bool ProjectManager::IsProjectIdle() {
+  const auto& project_manager = GetInstance();
+  const auto asset_load_snapshot = AssetManager::GetAssetLoadSnapshot();
+  return project_manager.new_project_path_.empty() && !project_manager.scan_assets_pending &&
+         project_manager.pending_assets.empty() && !project_manager.project_asset_load_dispatched &&
+         project_manager.pending_asset_size == 0 && !asset_load_snapshot.Active() && project_manager.start_scene_;
 }
 
 void ProjectManager::LoadAllPendingAssets() {
@@ -114,10 +136,26 @@ void ProjectManager::LoadAllPendingAssets() {
   if (project_manager.pending_assets.empty()) {
     return;
   }
-  for (const auto& i : project_manager.pending_assets) {
-    AssetManager::GetAssetImpl(i);
+
+  std::vector<Handle> handles;
+  handles.reserve(project_manager.pending_assets.size());
+  for (const auto& handle : project_manager.pending_assets) {
+    handles.emplace_back(handle);
   }
+
+  project_manager.pending_asset_size = handles.size();
+  [[maybe_unused]] const auto load_futures = AssetManager::RequestAssetLoads(project_manager.pending_assets);
+  project_manager.project_asset_load_dispatched = true;
   project_manager.pending_assets.clear();
+
+  if (ApplicationContext::Get().GetLayer<WindowLayer>()) {
+    return;
+  }
+
+  for (const auto& handle : handles) {
+    AssetManager::GetAssetImpl(handle);
+  }
+  project_manager.project_asset_load_dispatched = false;
   project_manager.pending_asset_size = 0;
 }
 
@@ -215,8 +253,14 @@ void ProjectManager::GetOrCreateProject(const std::filesystem::path& path) {
     DispatchScanAssetsTask();
   } else {
     ScanAssets();
-    LoadAllPendingAssets();
-    SetupDefaultScene();
+    if (ApplicationContext::Get().GetApplicationInfo().load_project_assets) {
+      LoadAllPendingAssets();
+    }
+    if (ApplicationContext::Get().GetApplicationInfo().load_project_start_scene) {
+      SetupDefaultScene();
+    } else {
+      project_manager.new_project_path_ = "";
+    }
   }
 }
 
@@ -293,6 +337,10 @@ void ProjectManager::Initialize() {
 void ProjectManager::OnDestroy() {
   auto& project_manager = GetInstance();
 
+  project_manager.scan_assets_pending = false;
+  project_manager.project_asset_load_dispatched = false;
+  project_manager.pending_asset_size = 0;
+  project_manager.pending_assets.clear();
   project_manager.assets_folder_.reset();
   project_manager.new_scene_customizer_.reset();
   project_manager.current_focused_folder_.reset();
@@ -701,9 +749,10 @@ void ProjectManager::OnInspect(const std::shared_ptr<EditorLayer>& editor_layer)
     ImGui::End();
   }
 
+  const auto asset_load_snapshot = AssetManager::GetAssetLoadSnapshot();
   if (project_manager.scan_assets_pending) {
-    ImGui::OpenPopup("Scanning files...");
-  } else if (project_manager.pending_asset_size != 0) {
+    ImGui::OpenPopup("Scanning assets...");
+  } else if (asset_load_snapshot.Active()) {
     ImGui::OpenPopup("Loading assets...");
   } else if (!project_manager.new_project_path_.empty()) {
     ImGui::OpenPopup("Loading Project...");
@@ -724,15 +773,30 @@ void ProjectManager::OnInspect(const std::shared_ptr<EditorLayer>& editor_layer)
   }
   if (ImGui::BeginPopupModal("Loading assets...", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
     ImGui::Text("Progress: ");
-    const float fraction =
-        1.0f - static_cast<float>(project_manager.pending_assets.size()) / project_manager.pending_asset_size;
-    const std::string text =
-        std::to_string(static_cast<int>(fraction * 100.0f)) + "% - " +
-        std::to_string(project_manager.pending_asset_size - project_manager.pending_assets.size()) + "/" +
-        std::to_string(project_manager.pending_asset_size);
+    const auto completed_asset_count =
+        asset_load_snapshot.completed + asset_load_snapshot.failed + asset_load_snapshot.cancelled;
+    const auto active_asset_count =
+        asset_load_snapshot.queued + asset_load_snapshot.loading_cpu + asset_load_snapshot.waiting_for_finalize;
+    auto total_asset_count = asset_load_snapshot.total;
+    total_asset_count = std::max(total_asset_count, completed_asset_count + active_asset_count);
+    total_asset_count = std::max(total_asset_count, project_manager.pending_asset_size);
+    const float fraction = total_asset_count == 0
+                               ? 1.0f
+                               : static_cast<float>(completed_asset_count) / static_cast<float>(total_asset_count);
+    const std::string text = std::to_string(static_cast<int>(fraction * 100.0f)) + "% - " +
+                             std::to_string(completed_asset_count) + "/" + std::to_string(total_asset_count);
     ImGui::ProgressBar(fraction, ImVec2(240, 0), text.c_str());
+    if (!asset_load_snapshot.active_asset_name.empty()) {
+      ImGui::Text("Asset: %s", asset_load_snapshot.active_asset_name.c_str());
+    }
+    if (!asset_load_snapshot.message.empty()) {
+      ImGui::Text("%s", asset_load_snapshot.message.c_str());
+    }
+    if (asset_load_snapshot.failed != 0 || asset_load_snapshot.cancelled != 0) {
+      ImGui::Text("Failed: %zu  Cancelled: %zu", asset_load_snapshot.failed, asset_load_snapshot.cancelled);
+    }
     ImGui::SetItemDefaultFocus();
-    if (project_manager.pending_asset_size == 0) {
+    if (!asset_load_snapshot.Active()) {
       ImGui::CloseCurrentPopup();
     }
     ImGui::EndPopup();

--- a/EvoEngine_SDK/src/Scene.cpp
+++ b/EvoEngine_SDK/src/Scene.cpp
@@ -781,6 +781,24 @@ bool Scene::LoadInternal(const std::filesystem::path& path) {
   return true;
 }
 
+bool Scene::SupportsStagedLoading(const std::filesystem::path& path) const {
+  return path.extension() == ".evescene";
+}
+
+std::shared_ptr<StagedAssetLoadPayload> Scene::LoadStagedPayloadInternal(const std::filesystem::path& path) const {
+  return IAsset::LoadStagedPayloadInternal(path);
+}
+
+bool Scene::ApplyStagedPayloadInternal(const std::filesystem::path&,
+                                       const std::shared_ptr<StagedAssetLoadPayload>& payload) {
+  const auto previous_scene = ApplicationContext::Get().GetActiveScene();
+  ApplicationContext::Get().Attach(std::shared_ptr<Scene>(this, [](Scene*) {
+  }));
+  const bool loaded = IAsset::ApplyStagedPayloadInternal({}, payload);
+  ApplicationContext::Get().Attach(previous_scene);
+  return loaded;
+}
+
 std::shared_ptr<Texture2D> Scene::GenerateThumbnailTexture() {
   return EditorLayer::FindIcon("Scene");
 }

--- a/EvoEngine_SDK/src/Shader.cpp
+++ b/EvoEngine_SDK/src/Shader.cpp
@@ -9,6 +9,15 @@
 #include "Utilities.hpp"
 
 using namespace evo_engine;
+
+namespace {
+class ShaderStagedLoadPayload final : public StagedAssetLoadPayload {
+ public:
+  std::string shader_code;
+  unsigned shader_type = static_cast<unsigned>(ShaderType::Unknown);
+};
+}  // namespace
+
 int string_resize_callback(ImGuiInputTextCallbackData* data) {
   if (data->EventFlag == ImGuiInputTextFlags_CallbackResize) {
     const auto my_str = static_cast<std::string*>(data->UserData);
@@ -81,6 +90,50 @@ bool Shader::LoadInternal(const std::filesystem::path& path) {
     EVOENGINE_ERROR("Failed to load!")
     return false;
   }
+  return true;
+}
+
+bool Shader::SupportsStagedLoading() const {
+  return true;
+}
+
+std::shared_ptr<StagedAssetLoadPayload> Shader::LoadStagedPayloadInternal(const std::filesystem::path& path) const {
+  if (!std::filesystem::exists(path)) {
+    EVOENGINE_ERROR("Not exist!")
+    return {};
+  }
+  try {
+    const std::ifstream stream(path.string());
+    std::stringstream string_stream;
+    string_stream << stream.rdbuf();
+    auto payload = std::make_shared<ShaderStagedLoadPayload>();
+    if (path.extension() == ".eveshader") {
+      const YAML::Node in = YAML::Load(string_stream.str());
+      if (in["shader_code"]) {
+        payload->shader_code = in["shader_code"].as<std::string>();
+      }
+      if (in["shader_type"]) {
+        payload->shader_type = in["shader_type"].as<unsigned>();
+      }
+    } else {
+      payload->shader_type = static_cast<unsigned>(ShaderType::Unknown);
+      payload->shader_code = string_stream.str();
+    }
+    return payload;
+  } catch (const std::exception& e) {
+    EVOENGINE_ERROR("Failed to load staged shader payload: " + std::string(e.what()))
+    return {};
+  }
+}
+
+bool Shader::ApplyStagedPayloadInternal(const std::filesystem::path&,
+                                        const std::shared_ptr<StagedAssetLoadPayload>& payload) {
+  const auto shader_payload = std::dynamic_pointer_cast<ShaderStagedLoadPayload>(payload);
+  if (!shader_payload) {
+    return false;
+  }
+  shader_code = std::move(shader_payload->shader_code);
+  shader_type = shader_payload->shader_type;
   return true;
 }
 

--- a/EvoEngine_SDK/src/Strands.cpp
+++ b/EvoEngine_SDK/src/Strands.cpp
@@ -121,6 +121,30 @@ struct HairHeader {
   }
 };
 
+namespace {
+class StrandsStagedLoadPayload final : public StagedAssetLoadPayload {
+ public:
+  StrandPointAttributes strand_point_attributes = {};
+  std::vector<glm::uint> segment_raw_indices;
+  std::vector<StrandPoint> strand_points;
+};
+
+std::vector<glm::uint> BuildSegmentRawIndicesFromStrands(const std::vector<glm::uint>& strands) {
+  std::vector<glm::uint> segment_raw_indices;
+  if (strands.size() < 2) {
+    return segment_raw_indices;
+  }
+  for (auto strand = strands.begin(); strand != strands.end() - 1; ++strand) {
+    const int start = static_cast<int>(*strand);
+    const int end = static_cast<int>(*(strand + 1)) - 3;
+    for (int i = start; i < end; i++) {
+      segment_raw_indices.emplace_back(static_cast<glm::uint>(i));
+    }
+  }
+  return segment_raw_indices;
+}
+}  // namespace
+
 bool Strands::LoadInternal(const std::filesystem::path& path) {
   if (path.extension() == ".evestrands") {
     return IAsset::LoadInternal(path);
@@ -207,6 +231,130 @@ bool Strands::LoadInternal(const std::filesystem::path& path) {
     }
   }
   return false;
+}
+
+bool Strands::SupportsStagedLoading(const std::filesystem::path& path) const {
+  return path.extension() == ".evestrands" || path.extension() == ".hair";
+}
+
+std::shared_ptr<StagedAssetLoadPayload> Strands::LoadStagedPayloadInternal(const std::filesystem::path& path) const {
+  try {
+    auto payload = std::make_shared<StrandsStagedLoadPayload>();
+    if (path.extension() == ".evestrands") {
+      const std::ifstream stream(path.string());
+      std::stringstream string_stream;
+      string_stream << stream.rdbuf();
+      const YAML::Node in = YAML::Load(string_stream.str());
+      if (in["segment_raw_indices_"] && in["strand_points_"]) {
+        const auto& segment_data = in["segment_raw_indices_"].as<YAML::Binary>();
+        payload->segment_raw_indices.resize(segment_data.size() / sizeof(glm::uint));
+        std::memcpy(payload->segment_raw_indices.data(), segment_data.data(), segment_data.size());
+
+        const auto& point_data = in["strand_points_"].as<YAML::Binary>();
+        payload->strand_points.resize(point_data.size() / sizeof(StrandPoint));
+        std::memcpy(payload->strand_points.data(), point_data.data(), point_data.size());
+
+        payload->strand_point_attributes.tex_coord = true;
+        payload->strand_point_attributes.color = true;
+        payload->strand_point_attributes.normal = true;
+      }
+      return payload;
+    }
+
+    if (path.extension() == ".hair") {
+      std::ifstream input(path.string().c_str(), std::ios::binary);
+      HairHeader header;
+      input.read(reinterpret_cast<char*>(&header), sizeof(HairHeader));
+      if (!input || strncmp(header.magic, "HAIR", 4) != 0) {
+        return {};
+      }
+      header.file_info[87] = 0;
+
+      auto strand_segments = std::vector<unsigned short>(header.num_strands);
+      if (header.HasSegments()) {
+        input.read(reinterpret_cast<char*>(strand_segments.data()), header.num_strands * sizeof(unsigned short));
+        if (!input) {
+          return {};
+        }
+      } else {
+        std::fill(strand_segments.begin(), strand_segments.end(), header.default_num_segments);
+      }
+
+      auto strands = std::vector<glm::uint>(strand_segments.size() + 1);
+      auto strand = strands.begin();
+      *strand++ = 0;
+      for (auto segments : strand_segments) {
+        *strand = *(strand - 1) + 1 + segments;
+        ++strand;
+      }
+
+      if (!header.HasPoints()) {
+        return {};
+      }
+      auto points = std::vector<glm::vec3>(header.num_points);
+      input.read(reinterpret_cast<char*>(points.data()), header.num_points * sizeof(glm::vec3));
+      if (!input) {
+        return {};
+      }
+
+      auto thickness = std::vector<float>(header.num_points);
+      if (header.HasThickness()) {
+        input.read(reinterpret_cast<char*>(thickness.data()), header.num_points * sizeof(float));
+        if (!input) {
+          return {};
+        }
+      } else {
+        std::fill(thickness.begin(), thickness.end(), header.default_thickness);
+      }
+
+      auto color = std::vector<glm::vec3>(header.num_points);
+      if (header.HasColor()) {
+        input.read(reinterpret_cast<char*>(color.data()), header.num_points * sizeof(glm::vec3));
+        if (!input) {
+          return {};
+        }
+      } else {
+        std::fill(color.begin(), color.end(), header.default_color);
+      }
+
+      auto alpha = std::vector<float>(header.num_points);
+      if (header.HasAlpha()) {
+        input.read(reinterpret_cast<char*>(alpha.data()), header.num_points * sizeof(float));
+        if (!input) {
+          return {};
+        }
+      } else {
+        std::fill(alpha.begin(), alpha.end(), header.default_alpha);
+      }
+
+      payload->strand_points.resize(header.num_points);
+      for (int i = 0; i < header.num_points; i++) {
+        payload->strand_points[i].position = points[i];
+        payload->strand_points[i].thickness = thickness[i];
+        payload->strand_points[i].color = glm::vec4(color[i], alpha[i]);
+        payload->strand_points[i].tex_coord = 0.0f;
+      }
+      payload->segment_raw_indices = BuildSegmentRawIndicesFromStrands(strands);
+      payload->strand_point_attributes.tex_coord = true;
+      payload->strand_point_attributes.color = true;
+      return payload;
+    }
+  } catch (const std::exception& e) {
+    EVOENGINE_ERROR("Failed to load staged strands payload: " + std::string(e.what()))
+  }
+  return {};
+}
+
+bool Strands::ApplyStagedPayloadInternal(const std::filesystem::path&,
+                                         const std::shared_ptr<StagedAssetLoadPayload>& payload) {
+  const auto strands_payload = std::dynamic_pointer_cast<StrandsStagedLoadPayload>(payload);
+  if (!strands_payload || strands_payload->segment_raw_indices.empty() || strands_payload->strand_points.empty()) {
+    return false;
+  }
+  segment_raw_indices_ = std::move(strands_payload->segment_raw_indices);
+  strand_points_ = std::move(strands_payload->strand_points);
+  PrepareStrands(strands_payload->strand_point_attributes);
+  return true;
 }
 
 bool Strands::OnInspect(const std::shared_ptr<EditorLayer>& editor_layer) {

--- a/EvoEngine_SDK/src/TaskRuntime.cpp
+++ b/EvoEngine_SDK/src/TaskRuntime.cpp
@@ -346,8 +346,7 @@ size_t TaskRuntime::RunReadyMainThreadTasks(const size_t max_task_size) {
 
 bool TaskRuntime::IsHandleValidLocked(const TaskHandle& handle) const {
   return handle.index_ >= 0 && static_cast<size_t>(handle.index_) < tasks_.size() && tasks_[handle.index_] &&
-         tasks_[handle.index_]->generation == handle.generation_ &&
-         tasks_[handle.index_]->state != TaskState::Recycled;
+         tasks_[handle.index_]->generation == handle.generation_ && tasks_[handle.index_]->state != TaskState::Recycled;
 }
 
 bool TaskRuntime::ExecutorHasTasks(const ExecutorState& executor) {

--- a/EvoEngine_SDK/src/TaskRuntime.cpp
+++ b/EvoEngine_SDK/src/TaskRuntime.cpp
@@ -1,0 +1,687 @@
+#include "TaskRuntime.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <utility>
+
+using namespace evo_engine;
+
+namespace {
+thread_local TaskRuntime* g_current_task_runtime = nullptr;
+thread_local TaskExecutorType g_current_executor = TaskExecutorType::MainThread;
+
+TaskExecutorType ExecutorFromAffinity(const ThreadAffinity affinity) {
+  switch (affinity) {
+    case ThreadAffinity::MainThread:
+      return TaskExecutorType::MainThread;
+    case ThreadAffinity::Worker:
+      return TaskExecutorType::Worker;
+    case ThreadAffinity::AssetIo:
+      return TaskExecutorType::AssetIo;
+    case ThreadAffinity::Render:
+      return TaskExecutorType::Render;
+    case ThreadAffinity::Background:
+      return TaskExecutorType::Background;
+    case ThreadAffinity::Any:
+    default:
+      return TaskExecutorType::Worker;
+  }
+}
+
+const char* ExecutorName(const TaskExecutorType executor) {
+  switch (executor) {
+    case TaskExecutorType::MainThread:
+      return "MainThread";
+    case TaskExecutorType::Worker:
+      return "Worker";
+    case TaskExecutorType::AssetIo:
+      return "AssetIo";
+    case TaskExecutorType::Render:
+      return "Render";
+    case TaskExecutorType::Background:
+      return "Background";
+    default:
+      return "Unknown";
+  }
+}
+}  // namespace
+
+CancellationToken::CancellationToken(std::shared_ptr<std::atomic<bool>> state) : state_(std::move(state)) {
+}
+
+bool CancellationToken::IsCancellationRequested() const {
+  return state_ && state_->load();
+}
+
+bool CancellationToken::Valid() const {
+  return state_ != nullptr;
+}
+
+CancellationToken CancellationSource::GetToken() const {
+  return CancellationToken(state_);
+}
+
+void CancellationSource::Cancel() const {
+  state_->store(true);
+}
+
+bool CancellationSource::IsCancellationRequested() const {
+  return state_->load();
+}
+
+int TaskHandle::GetIndex() const {
+  return index_;
+}
+
+uint32_t TaskHandle::GetGeneration() const {
+  return generation_;
+}
+
+bool TaskHandle::Valid() const {
+  return index_ >= 0 && generation_ != 0;
+}
+
+void TaskGroup::Add(const TaskHandle& handle) {
+  if (handle.Valid()) {
+    handles_.emplace_back(handle);
+  }
+}
+
+void TaskGroup::Clear() {
+  handles_.clear();
+}
+
+bool TaskGroup::Empty() const {
+  return handles_.empty();
+}
+
+const std::vector<TaskHandle>& TaskGroup::GetHandles() const {
+  return handles_;
+}
+
+TaskRuntime::TaskRuntime() {
+  main_thread_id_ = std::this_thread::get_id();
+  main_executor_.type = TaskExecutorType::MainThread;
+  main_executor_.name = "MainThread";
+  worker_executor_.type = TaskExecutorType::Worker;
+  asset_io_executor_.type = TaskExecutorType::AssetIo;
+  render_executor_.type = TaskExecutorType::Render;
+  background_executor_.type = TaskExecutorType::Background;
+
+  TaskRuntimeSettings settings;
+  settings.worker_thread_size = 1;
+  settings.asset_io_thread_size = 0;
+  settings.render_thread_size = 0;
+  settings.background_thread_size = 0;
+  Initialize(settings);
+}
+
+TaskRuntime::~TaskRuntime() {
+  Shutdown();
+}
+
+void TaskRuntime::Initialize(const TaskRuntimeSettings& settings) {
+  Shutdown();
+  shutting_down_ = false;
+  running_task_size_ = 0;
+  submitted_task_size_ = 0;
+  completed_task_size_ = 0;
+  failed_task_size_ = 0;
+  main_thread_id_ = std::this_thread::get_id();
+  StartExecutor(worker_executor_, std::max<size_t>(1, settings.worker_thread_size), "Worker");
+  StartExecutor(asset_io_executor_, settings.asset_io_thread_size, "AssetIo");
+  StartExecutor(render_executor_, settings.render_thread_size, "Render");
+  StartExecutor(background_executor_, settings.background_thread_size, "Background");
+}
+
+void TaskRuntime::Shutdown() {
+  shutting_down_ = true;
+  StopExecutor(worker_executor_);
+  StopExecutor(asset_io_executor_);
+  StopExecutor(render_executor_);
+  StopExecutor(background_executor_);
+  {
+    std::lock_guard lock(main_executor_.mutex);
+    main_executor_.high_priority_tasks.clear();
+    main_executor_.normal_priority_tasks.clear();
+    main_executor_.low_priority_tasks.clear();
+    main_executor_.queued_task_size = 0;
+  }
+  {
+    std::lock_guard lock(task_mutex_);
+    tasks_.clear();
+    recycled_task_indices_ = {};
+  }
+  task_finished_cv_.notify_all();
+}
+
+void TaskRuntime::ResizeWorker(const size_t worker_size) {
+  StopExecutor(worker_executor_);
+  StartExecutor(worker_executor_, std::max<size_t>(1, worker_size), "Worker");
+}
+
+size_t TaskRuntime::GetWorkerSize() const {
+  return GetThreadSize(TaskExecutorType::Worker);
+}
+
+size_t TaskRuntime::GetThreadSize(const TaskExecutorType executor) const {
+  const auto& executor_state = GetExecutor(executor);
+  std::lock_guard lock(executor_state.mutex);
+  return executor_state.threads.size();
+}
+
+bool TaskRuntime::IsMainThread() const {
+  return std::this_thread::get_id() == main_thread_id_;
+}
+
+bool TaskRuntime::IsExecutorThread(const TaskExecutorType executor) const {
+  return g_current_task_runtime == this && g_current_executor == executor;
+}
+
+TaskRuntimeStats TaskRuntime::GetStats() const {
+  TaskRuntimeStats stats;
+  stats.worker_thread_size = GetThreadSize(TaskExecutorType::Worker);
+  stats.asset_io_thread_size = GetThreadSize(TaskExecutorType::AssetIo);
+  stats.render_thread_size = GetThreadSize(TaskExecutorType::Render);
+  stats.background_thread_size = GetThreadSize(TaskExecutorType::Background);
+  stats.running_task_size = running_task_size_.load();
+  stats.submitted_task_size = submitted_task_size_.load();
+  stats.completed_task_size = completed_task_size_.load();
+  stats.failed_task_size = failed_task_size_.load();
+  for (const auto executor : {TaskExecutorType::MainThread, TaskExecutorType::Worker, TaskExecutorType::AssetIo,
+                              TaskExecutorType::Render, TaskExecutorType::Background}) {
+    const auto& executor_state = GetExecutor(executor);
+    std::lock_guard lock(executor_state.mutex);
+    stats.queued_task_size += executor_state.queued_task_size;
+  }
+  return stats;
+}
+
+TaskHandle TaskRuntime::Schedule(const std::vector<TaskHandle>& dependencies, const TaskOptions& options,
+                                 std::function<void()>&& function) {
+  if (shutting_down_) {
+    return {};
+  }
+
+  TaskHandle handle;
+  {
+    std::lock_guard lock(task_mutex_);
+    handle = AllocateTaskLocked();
+    auto& task = *tasks_[handle.index_];
+    task.state = TaskState::Pending;
+    task.dependencies.clear();
+    task.dependents.clear();
+    task.pending_dependency_size = 0;
+    task.scheduled = false;
+    task.options = options;
+    if (task.options.affinity != ThreadAffinity::Any) {
+      task.options.executor = ExecutorFromAffinity(task.options.affinity);
+    }
+    task.function = std::move(function);
+    task.exception = nullptr;
+
+    for (const auto& dependency : dependencies) {
+      if (!IsHandleValidLocked(dependency)) {
+        continue;
+      }
+      task.dependencies.emplace_back(dependency);
+      auto& dependency_task = *tasks_[dependency.index_];
+      if (dependency_task.state != TaskState::Completed) {
+        ++task.pending_dependency_size;
+        dependency_task.dependents.emplace_back(handle);
+      }
+    }
+  }
+  ++submitted_task_size_;
+  return handle;
+}
+
+TaskHandle TaskRuntime::Schedule(const std::vector<TaskHandle>& dependencies, std::function<void()>&& function) {
+  return Schedule(dependencies, TaskOptions{}, std::move(function));
+}
+
+TaskHandle TaskRuntime::Schedule(std::function<void()>&& function) {
+  return Schedule({}, TaskOptions{}, std::move(function));
+}
+
+TaskHandle TaskRuntime::Combine(const std::vector<TaskHandle>& dependencies) {
+  return Schedule(dependencies, []() {
+  });
+}
+
+TaskHandle TaskRuntime::Combine(const TaskGroup& task_group) {
+  return Combine(task_group.GetHandles());
+}
+
+void TaskRuntime::Execute(const TaskHandle& handle) {
+  std::vector<TaskHandle> ready_tasks;
+  {
+    std::lock_guard lock(task_mutex_);
+    if (!IsHandleValidLocked(handle)) {
+      return;
+    }
+    std::vector<int> visited_indices;
+    StartTaskGraphLocked(handle, ready_tasks, visited_indices);
+  }
+  QueueReadyTasks(ready_tasks);
+}
+
+void TaskRuntime::Wait(const TaskHandle& handle) {
+  if (!handle.Valid()) {
+    return;
+  }
+
+  Execute(handle);
+  std::exception_ptr exception;
+  while (true) {
+    {
+      std::unique_lock lock(task_mutex_);
+      if (!IsHandleValidLocked(handle)) {
+        return;
+      }
+      const auto& task = *tasks_[handle.index_];
+      if (task.state == TaskState::Completed) {
+        exception = task.exception;
+        break;
+      }
+    }
+
+    TaskHandle waiting_task;
+    TaskExecutorType waiting_executor = TaskExecutorType::Worker;
+    if (TryPopTaskForWaiting(waiting_task, waiting_executor)) {
+      RunTask(waiting_task, waiting_executor);
+      continue;
+    }
+
+    std::unique_lock lock(task_mutex_);
+    task_finished_cv_.wait_for(lock, std::chrono::milliseconds(1));
+  }
+
+  {
+    std::lock_guard lock(task_mutex_);
+    std::vector<TaskHandle> task_tree;
+    CollectTaskTreeLocked(handle, task_tree);
+    for (const auto& task_handle : task_tree) {
+      if (CanRecycleTaskLocked(task_handle)) {
+        RecycleTaskLocked(task_handle);
+      }
+    }
+  }
+
+  if (exception) {
+    std::rethrow_exception(exception);
+  }
+}
+
+bool TaskRuntime::IsCompleted(const TaskHandle& handle) const {
+  std::lock_guard lock(task_mutex_);
+  return IsHandleValidLocked(handle) && tasks_[handle.index_]->state == TaskState::Completed;
+}
+
+std::exception_ptr TaskRuntime::GetException(const TaskHandle& handle) const {
+  std::lock_guard lock(task_mutex_);
+  if (!IsHandleValidLocked(handle)) {
+    return nullptr;
+  }
+  return tasks_[handle.index_]->exception;
+}
+
+size_t TaskRuntime::RunReadyMainThreadTasks(const size_t max_task_size) {
+  if (!IsMainThread()) {
+    return 0;
+  }
+
+  size_t executed_task_size = 0;
+  while (max_task_size == 0 || executed_task_size < max_task_size) {
+    TaskHandle handle;
+    if (!TryPopTask(main_executor_, handle)) {
+      break;
+    }
+    RunTask(handle, TaskExecutorType::MainThread);
+    ++executed_task_size;
+  }
+  return executed_task_size;
+}
+
+bool TaskRuntime::IsHandleValidLocked(const TaskHandle& handle) const {
+  return handle.index_ >= 0 && static_cast<size_t>(handle.index_) < tasks_.size() && tasks_[handle.index_] &&
+         tasks_[handle.index_]->generation == handle.generation_ &&
+         tasks_[handle.index_]->state != TaskState::Recycled;
+}
+
+bool TaskRuntime::ExecutorHasTasks(const ExecutorState& executor) {
+  return !executor.high_priority_tasks.empty() || !executor.normal_priority_tasks.empty() ||
+         !executor.low_priority_tasks.empty();
+}
+
+std::deque<TaskHandle>& TaskRuntime::GetQueueForPriority(ExecutorState& executor, const TaskPriority priority) {
+  switch (priority) {
+    case TaskPriority::High:
+      return executor.high_priority_tasks;
+    case TaskPriority::Low:
+      return executor.low_priority_tasks;
+    case TaskPriority::Normal:
+    default:
+      return executor.normal_priority_tasks;
+  }
+}
+
+TaskRuntime::ExecutorState& TaskRuntime::GetExecutor(const TaskExecutorType executor) {
+  switch (executor) {
+    case TaskExecutorType::MainThread:
+      return main_executor_;
+    case TaskExecutorType::AssetIo:
+      return asset_io_executor_;
+    case TaskExecutorType::Render:
+      return render_executor_;
+    case TaskExecutorType::Background:
+      return background_executor_;
+    case TaskExecutorType::Worker:
+    default:
+      return worker_executor_;
+  }
+}
+
+const TaskRuntime::ExecutorState& TaskRuntime::GetExecutor(const TaskExecutorType executor) const {
+  return const_cast<TaskRuntime*>(this)->GetExecutor(executor);
+}
+
+TaskRuntime::ExecutorState& TaskRuntime::GetRunnableExecutor(const TaskExecutorType executor) {
+  auto& executor_state = GetExecutor(executor);
+  if (executor != TaskExecutorType::MainThread) {
+    std::lock_guard lock(executor_state.mutex);
+    if (!executor_state.threads.empty()) {
+      return executor_state;
+    }
+  } else {
+    return executor_state;
+  }
+  return worker_executor_;
+}
+
+TaskHandle TaskRuntime::AllocateTaskLocked() {
+  TaskHandle handle;
+  if (!recycled_task_indices_.empty()) {
+    handle.index_ = recycled_task_indices_.front();
+    recycled_task_indices_.pop();
+    handle.generation_ = tasks_[handle.index_]->generation;
+  } else {
+    handle.index_ = static_cast<int>(tasks_.size());
+    handle.generation_ = 1;
+    tasks_.emplace_back(std::make_shared<TaskRecord>());
+    tasks_.back()->generation = handle.generation_;
+  }
+  return handle;
+}
+
+void TaskRuntime::StartExecutor(ExecutorState& executor, const size_t thread_size, const std::string& name) {
+  executor.name = name;
+  executor.stopping = false;
+  for (size_t i = 0; i < thread_size; ++i) {
+    executor.threads.emplace_back(std::make_unique<std::thread>([this, &executor]() {
+      ExecutorLoop(executor);
+    }));
+  }
+}
+
+void TaskRuntime::StopExecutor(ExecutorState& executor) {
+  {
+    std::lock_guard lock(executor.mutex);
+    executor.stopping = true;
+  }
+  executor.cv.notify_all();
+  for (const auto& thread : executor.threads) {
+    if (thread && thread->joinable()) {
+      thread->join();
+    }
+  }
+  executor.threads.clear();
+  {
+    std::lock_guard lock(executor.mutex);
+    executor.high_priority_tasks.clear();
+    executor.normal_priority_tasks.clear();
+    executor.low_priority_tasks.clear();
+    executor.queued_task_size = 0;
+    executor.stopping = false;
+  }
+}
+
+void TaskRuntime::ExecutorLoop(ExecutorState& executor) {
+  while (true) {
+    TaskHandle handle;
+    {
+      std::unique_lock lock(executor.mutex);
+      executor.cv.wait(lock, [&executor]() {
+        return executor.stopping || ExecutorHasTasks(executor);
+      });
+      if (executor.stopping && !ExecutorHasTasks(executor)) {
+        return;
+      }
+      if (!executor.high_priority_tasks.empty()) {
+        handle = executor.high_priority_tasks.front();
+        executor.high_priority_tasks.pop_front();
+      } else if (!executor.normal_priority_tasks.empty()) {
+        handle = executor.normal_priority_tasks.front();
+        executor.normal_priority_tasks.pop_front();
+      } else if (!executor.low_priority_tasks.empty()) {
+        handle = executor.low_priority_tasks.front();
+        executor.low_priority_tasks.pop_front();
+      }
+      if (executor.queued_task_size > 0) {
+        --executor.queued_task_size;
+      }
+    }
+    RunTask(handle, executor.type);
+  }
+}
+
+void TaskRuntime::QueueReadyTask(const TaskHandle& handle) {
+  if (!handle.Valid()) {
+    return;
+  }
+
+  TaskOptions options;
+  {
+    std::lock_guard lock(task_mutex_);
+    if (!IsHandleValidLocked(handle)) {
+      return;
+    }
+    options = tasks_[handle.index_]->options;
+  }
+
+  auto& executor = GetRunnableExecutor(options.executor);
+  {
+    std::lock_guard lock(executor.mutex);
+    GetQueueForPriority(executor, options.priority).emplace_back(handle);
+    ++executor.queued_task_size;
+  }
+  executor.cv.notify_one();
+}
+
+void TaskRuntime::QueueReadyTasks(const std::vector<TaskHandle>& handles) {
+  for (const auto& handle : handles) {
+    QueueReadyTask(handle);
+  }
+}
+
+bool TaskRuntime::TryPopTask(ExecutorState& executor, TaskHandle& handle) {
+  std::lock_guard lock(executor.mutex);
+  if (!executor.high_priority_tasks.empty()) {
+    handle = executor.high_priority_tasks.front();
+    executor.high_priority_tasks.pop_front();
+  } else if (!executor.normal_priority_tasks.empty()) {
+    handle = executor.normal_priority_tasks.front();
+    executor.normal_priority_tasks.pop_front();
+  } else if (!executor.low_priority_tasks.empty()) {
+    handle = executor.low_priority_tasks.front();
+    executor.low_priority_tasks.pop_front();
+  } else {
+    return false;
+  }
+  if (executor.queued_task_size > 0) {
+    --executor.queued_task_size;
+  }
+  return true;
+}
+
+bool TaskRuntime::TryPopTaskForWaiting(TaskHandle& handle, TaskExecutorType& executor) {
+  if (IsMainThread()) {
+    executor = TaskExecutorType::MainThread;
+    return TryPopTask(main_executor_, handle);
+  }
+  if (g_current_task_runtime != this) {
+    return false;
+  }
+  executor = g_current_executor;
+  return TryPopTask(GetExecutor(executor), handle);
+}
+
+void TaskRuntime::RunTask(const TaskHandle& handle, const TaskExecutorType executor) {
+  std::function<void()> function;
+  CancellationToken cancellation_token;
+  TaskOptions options;
+  {
+    std::lock_guard lock(task_mutex_);
+    if (!IsHandleValidLocked(handle)) {
+      return;
+    }
+    auto& task = *tasks_[handle.index_];
+    if (task.state != TaskState::Queued) {
+      return;
+    }
+    task.state = TaskState::Running;
+    function = task.function;
+    cancellation_token = task.options.cancellation_token;
+    options = task.options;
+  }
+
+  ++running_task_size_;
+  std::exception_ptr exception;
+  auto* previous_runtime = g_current_task_runtime;
+  const auto previous_executor = g_current_executor;
+  g_current_task_runtime = this;
+  g_current_executor = executor;
+  try {
+    if (!cancellation_token.IsCancellationRequested() && function) {
+      function();
+    }
+  } catch (...) {
+    exception = std::current_exception();
+  }
+  g_current_task_runtime = previous_runtime;
+  g_current_executor = previous_executor;
+  --running_task_size_;
+
+  std::vector<TaskHandle> ready_tasks;
+  {
+    std::lock_guard lock(task_mutex_);
+    if (!IsHandleValidLocked(handle)) {
+      return;
+    }
+    auto& task = *tasks_[handle.index_];
+    task.state = TaskState::Completed;
+    task.exception = exception;
+    ++completed_task_size_;
+    if (exception) {
+      ++failed_task_size_;
+      std::cerr << "[EvoEngine]Task failed on executor " << ExecutorName(executor);
+      if (!options.debug_name.empty()) {
+        std::cerr << " (" << options.debug_name << ")";
+      }
+      std::cerr << std::endl;
+    }
+
+    for (const auto& dependent_handle : task.dependents) {
+      if (!IsHandleValidLocked(dependent_handle)) {
+        continue;
+      }
+      auto& dependent_task = *tasks_[dependent_handle.index_];
+      if (dependent_task.pending_dependency_size > 0) {
+        --dependent_task.pending_dependency_size;
+      }
+      if (dependent_task.scheduled && dependent_task.pending_dependency_size == 0 &&
+          dependent_task.state == TaskState::Pending) {
+        dependent_task.state = TaskState::Queued;
+        ready_tasks.emplace_back(dependent_handle);
+      }
+    }
+  }
+  task_finished_cv_.notify_all();
+  QueueReadyTasks(ready_tasks);
+}
+
+void TaskRuntime::StartTaskGraphLocked(const TaskHandle& handle, std::vector<TaskHandle>& ready_tasks,
+                                       std::vector<int>& visited_indices) {
+  if (!IsHandleValidLocked(handle)) {
+    return;
+  }
+  if (std::find(visited_indices.begin(), visited_indices.end(), handle.index_) != visited_indices.end()) {
+    return;
+  }
+  visited_indices.emplace_back(handle.index_);
+
+  auto& task = *tasks_[handle.index_];
+  for (const auto& dependency : task.dependencies) {
+    StartTaskGraphLocked(dependency, ready_tasks, visited_indices);
+  }
+
+  if (!task.scheduled) {
+    task.scheduled = true;
+  }
+  if (task.pending_dependency_size == 0 && task.state == TaskState::Pending) {
+    task.state = TaskState::Queued;
+    ready_tasks.emplace_back(handle);
+  }
+}
+
+void TaskRuntime::CollectTaskTreeLocked(const TaskHandle& handle, std::vector<TaskHandle>& task_tree) const {
+  if (!IsHandleValidLocked(handle)) {
+    return;
+  }
+  if (std::find_if(task_tree.begin(), task_tree.end(), [handle](const TaskHandle& other) {
+        return other.GetIndex() == handle.GetIndex();
+      }) != task_tree.end()) {
+    return;
+  }
+  task_tree.emplace_back(handle);
+  for (const auto& dependency : tasks_[handle.index_]->dependencies) {
+    CollectTaskTreeLocked(dependency, task_tree);
+  }
+}
+
+bool TaskRuntime::CanRecycleTaskLocked(const TaskHandle& handle) const {
+  if (!IsHandleValidLocked(handle)) {
+    return false;
+  }
+  const auto& task = *tasks_[handle.index_];
+  if (task.state != TaskState::Completed) {
+    return false;
+  }
+  for (const auto& dependent : task.dependents) {
+    if (IsHandleValidLocked(dependent) && tasks_[dependent.index_]->state != TaskState::Completed) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void TaskRuntime::RecycleTaskLocked(const TaskHandle& handle) {
+  if (!IsHandleValidLocked(handle)) {
+    return;
+  }
+  auto& task = *tasks_[handle.index_];
+  task.state = TaskState::Recycled;
+  task.dependencies.clear();
+  task.dependents.clear();
+  task.pending_dependency_size = 0;
+  task.scheduled = false;
+  task.options = {};
+  task.function = nullptr;
+  task.exception = nullptr;
+  ++task.generation;
+  if (task.generation == 0) {
+    task.generation = 1;
+  }
+  recycled_task_indices_.emplace(handle.index_);
+}

--- a/EvoEngine_SDK/src/Texture2D.cpp
+++ b/EvoEngine_SDK/src/Texture2D.cpp
@@ -10,6 +10,76 @@
 #include "TextureStorage.hpp"
 using namespace evo_engine;
 
+namespace {
+struct Texture2DStagedLoadPayload final : StagedAssetLoadPayload {
+  bool red_channel = false;
+  bool green_channel = false;
+  bool blue_channel = false;
+  bool alpha_channel = false;
+  bool hdr = false;
+  glm::uvec2 resolution = glm::uvec2(0);
+  std::vector<glm::vec4> pixels;
+};
+
+void DecodeSerializedTexture2D(const YAML::Node& in, Texture2DStagedLoadPayload& payload) {
+  if (in["red_channel"])
+    payload.red_channel = in["red_channel"].as<bool>();
+  if (in["green_channel"])
+    payload.green_channel = in["green_channel"].as<bool>();
+  if (in["blue_channel"])
+    payload.blue_channel = in["blue_channel"].as<bool>();
+  if (in["alpha_channel"])
+    payload.alpha_channel = in["alpha_channel"].as<bool>();
+  if (in["hdr"])
+    payload.hdr = in["hdr"].as<bool>();
+
+  glm::ivec2 resolution = glm::ivec2(0);
+  if (in["resolution"])
+    resolution = in["resolution"].as<glm::ivec2>();
+  payload.resolution = glm::uvec2(glm::max(resolution.x, 0), glm::max(resolution.y, 0));
+
+  if (payload.resolution.x == 0 || payload.resolution.y == 0) {
+    return;
+  }
+
+  if (payload.hdr) {
+    Serialization::DeserializeVector("pixels", payload.pixels, in);
+    return;
+  }
+
+  size_t target_channel_size = 0;
+  if (payload.red_channel)
+    target_channel_size++;
+  if (payload.green_channel)
+    target_channel_size++;
+  if (payload.blue_channel)
+    target_channel_size++;
+  if (payload.alpha_channel)
+    target_channel_size++;
+
+  std::vector<unsigned char> transferred_pixels;
+  Serialization::DeserializeVector("pixels", transferred_pixels, in);
+  transferred_pixels.resize(payload.resolution.x * payload.resolution.y * target_channel_size);
+  payload.pixels.resize(payload.resolution.x * payload.resolution.y);
+
+  Jobs::RunParallelFor(payload.pixels.size(), [&](size_t i) {
+    for (int channel = 0; channel < target_channel_size; channel++) {
+      payload.pixels[i][channel] =
+          glm::clamp(transferred_pixels[i * target_channel_size + channel] / 256.f, 0.f, 1.f);
+    }
+    if (target_channel_size < 4) {
+      payload.pixels[i][3] = 1.f;
+    }
+    if (target_channel_size < 3) {
+      payload.pixels[i][2] = 0.f;
+    }
+    if (target_channel_size < 2) {
+      payload.pixels[i][1] = 0.f;
+    }
+  });
+}
+}  // namespace
+
 void Texture2D::SetData(const std::vector<glm::vec4>& data, const glm::uvec2& resolution, const bool local_copy) {
   auto& texture_storage = TextureStorage::RefTexture2DStorage(texture_storage_handle_);
   texture_storage.SetData(data, resolution);
@@ -112,6 +182,81 @@ bool Texture2D::LoadInternal(const std::filesystem::path& path) {
     return false;
   }
   stbi_image_free(data);
+  return true;
+}
+
+bool Texture2D::SupportsStagedLoading() const {
+  return true;
+}
+
+std::shared_ptr<StagedAssetLoadPayload> Texture2D::LoadStagedPayloadInternal(const std::filesystem::path& path) const {
+  auto payload = std::make_shared<Texture2DStagedLoadPayload>();
+  if (path.extension() == ".evetexture2d") {
+    std::ifstream stream(path.string());
+    std::stringstream string_stream;
+    string_stream << stream.rdbuf();
+    const YAML::Node in = YAML::Load(string_stream.str());
+    DecodeSerializedTexture2D(in, *payload);
+    return payload;
+  }
+
+  payload->hdr = path.extension() == ".hdr";
+  stbi_set_flip_vertically_on_load(true);
+  int width = 0;
+  int height = 0;
+  int nr_components = 0;
+
+  const float actual_gamma = payload->hdr ? 2.2f : 1.f;
+  stbi_hdr_to_ldr_gamma(actual_gamma);
+  stbi_ldr_to_hdr_gamma(actual_gamma);
+
+  void* data = stbi_loadf(path.string().c_str(), &width, &height, &nr_components, STBI_rgb_alpha);
+  if (!data) {
+    EVOENGINE_ERROR("Texture failed to load at path: " + path.filename().string());
+    return {};
+  }
+
+  if (nr_components == 1) {
+    payload->red_channel = true;
+  } else if (nr_components == 2) {
+    payload->red_channel = true;
+    payload->green_channel = true;
+  } else if (nr_components == 3) {
+    payload->red_channel = true;
+    payload->green_channel = true;
+    payload->blue_channel = true;
+  } else if (nr_components == 4) {
+    payload->red_channel = true;
+    payload->green_channel = true;
+    payload->blue_channel = true;
+    payload->alpha_channel = true;
+  }
+
+  payload->resolution = glm::uvec2(width, height);
+  payload->pixels.resize(width * height);
+  memcpy(payload->pixels.data(), data, sizeof(glm::vec4) * width * height);
+  stbi_image_free(data);
+  return payload;
+}
+
+bool Texture2D::ApplyStagedPayloadInternal(const std::filesystem::path&,
+                                           const std::shared_ptr<StagedAssetLoadPayload>& payload) {
+  const auto texture_payload = std::dynamic_pointer_cast<Texture2DStagedLoadPayload>(payload);
+  if (!texture_payload) {
+    return false;
+  }
+
+  hdr = texture_payload->hdr;
+  red_channel = texture_payload->red_channel;
+  green_channel = texture_payload->green_channel;
+  blue_channel = texture_payload->blue_channel;
+  alpha_channel = texture_payload->alpha_channel;
+  local_data_ = texture_payload->pixels;
+
+  if (!local_data_.empty() && texture_payload->resolution.x != 0 && texture_payload->resolution.y != 0) {
+    auto& texture_storage = TextureStorage::RefTexture2DStorage(texture_storage_handle_);
+    texture_storage.SetDataImmediately(local_data_, texture_payload->resolution);
+  }
   return true;
 }
 

--- a/EvoEngine_SDK/src/Texture2D.cpp
+++ b/EvoEngine_SDK/src/Texture2D.cpp
@@ -64,8 +64,7 @@ void DecodeSerializedTexture2D(const YAML::Node& in, Texture2DStagedLoadPayload&
 
   Jobs::RunParallelFor(payload.pixels.size(), [&](size_t i) {
     for (int channel = 0; channel < target_channel_size; channel++) {
-      payload.pixels[i][channel] =
-          glm::clamp(transferred_pixels[i * target_channel_size + channel] / 256.f, 0.f, 1.f);
+      payload.pixels[i][channel] = glm::clamp(transferred_pixels[i * target_channel_size + channel] / 256.f, 0.f, 1.f);
     }
     if (target_channel_size < 4) {
       payload.pixels[i][3] = 1.f;

--- a/EvoEngine_Tests/CMakeLists.txt
+++ b/EvoEngine_Tests/CMakeLists.txt
@@ -15,29 +15,71 @@ file(TO_CMAKE_PATH "${CMAKE_SOURCE_DIR}" EVOENGINE_TEST_SOURCE_DIR_NORMALIZED)
 file(TO_CMAKE_PATH "${Python3_EXECUTABLE}" EVOENGINE_TEST_PYTHON_EXECUTABLE_NORMALIZED)
 file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Rendering" EVOENGINE_TEST_SCRIPT_DIR_NORMALIZED)
 
-add_executable(EvoEngine_RenderTests
+add_executable(EvoEngine_Tests
+	Core/TaskRuntimeTest.cpp
+	Core/AssetManagerTest.cpp
 	Rendering/RenderDemoPythonApiTest.cpp
 	)
-target_link_libraries(EvoEngine_RenderTests
+target_link_libraries(EvoEngine_Tests
 	PRIVATE
+	EvoEngine_SDK
 	GTest::gtest_main
 	)
-target_include_directories(EvoEngine_RenderTests
+target_include_directories(EvoEngine_Tests
 	PRIVATE
+	${EVOENGINE_SDK_INCLUDES}
 	${3RDPARTY_DIR}/stb/stb
 	)
-target_compile_definitions(EvoEngine_RenderTests
+target_compile_definitions(EvoEngine_Tests
 	PRIVATE
 	EVOENGINE_TEST_SOURCE_DIR="${EVOENGINE_TEST_SOURCE_DIR_NORMALIZED}"
 	EVOENGINE_TEST_PYTHON_EXECUTABLE="${EVOENGINE_TEST_PYTHON_EXECUTABLE_NORMALIZED}"
 	EVOENGINE_TEST_SCRIPT_DIR="${EVOENGINE_TEST_SCRIPT_DIR_NORMALIZED}"
 	EVOENGINE_PYEVOENGINE_DIR="$<TARGET_FILE_DIR:PyEvoEngine>"
-	EVOENGINE_RENDER_TEST_DIR="$<TARGET_FILE_DIR:EvoEngine_RenderTests>"
+	EVOENGINE_RENDER_TEST_DIR="$<TARGET_FILE_DIR:EvoEngine_Tests>"
 	)
-add_dependencies(EvoEngine_RenderTests PyEvoEngine)
+add_dependencies(EvoEngine_Tests PyEvoEngine)
+evoengine_copy_resources(EvoEngine_Tests "$<TARGET_FILE_DIR:EvoEngine_Tests>")
+set_property(TARGET EvoEngine_Tests PROPERTY FOLDER Tests)
+
+add_custom_target(EvoEngine_RenderTests)
+add_dependencies(EvoEngine_RenderTests EvoEngine_Tests)
 set_property(TARGET EvoEngine_RenderTests PROPERTY FOLDER Tests)
 
-gtest_discover_tests(EvoEngine_RenderTests
-	WORKING_DIRECTORY "$<TARGET_FILE_DIR:EvoEngine_RenderTests>"
+gtest_discover_tests(EvoEngine_Tests
+	WORKING_DIRECTORY "$<TARGET_FILE_DIR:EvoEngine_Tests>"
+	TEST_FILTER TaskRuntime.*
+	PROPERTIES LABELS "core,jobs"
+	)
+gtest_discover_tests(EvoEngine_Tests
+	WORKING_DIRECTORY "$<TARGET_FILE_DIR:EvoEngine_Tests>"
+	TEST_FILTER AssetManager.*
+	PROPERTIES LABELS "core,assets,jobs"
+	)
+gtest_discover_tests(EvoEngine_Tests
+	WORKING_DIRECTORY "$<TARGET_FILE_DIR:EvoEngine_Tests>"
+	TEST_FILTER RenderingDemo.*
 	PROPERTIES LABELS "render,gpu,python"
 	)
+
+if(TARGET DemoApp)
+	set(EVOENGINE_DEMOAPP_SMOKE_TEST_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/DemoAppSmokeTest.run.yaml")
+	file(WRITE "${EVOENGINE_DEMOAPP_SMOKE_TEST_CONFIG}"
+"mode: smoke_test
+demo_setup: Rendering
+frames_after_play: 100
+max_load_frames: 30000
+max_play_frames: 1000
+exit_on_complete: true
+")
+	add_dependencies(EvoEngine_RenderTests DemoApp)
+	add_test(NAME DemoApp.PlayLoadedScene100Frames
+		COMMAND $<TARGET_FILE:DemoApp> --run-config "${EVOENGINE_DEMOAPP_SMOKE_TEST_CONFIG}"
+		)
+	set_tests_properties(DemoApp.PlayLoadedScene100Frames
+		PROPERTIES
+		WORKING_DIRECTORY "$<TARGET_FILE_DIR:DemoApp>"
+		LABELS "render,gpu,app"
+		TIMEOUT 240
+		)
+endif()

--- a/EvoEngine_Tests/Core/AssetManagerTest.cpp
+++ b/EvoEngine_Tests/Core/AssetManagerTest.cpp
@@ -1,0 +1,426 @@
+#include "EvoEngine_SDK_PCH.hpp"
+
+#include <gtest/gtest.h>
+
+#include "Application.hpp"
+#include "ApplicationContext.hpp"
+#include "AssetManager.hpp"
+#include "IAsset.hpp"
+#include "Jobs.hpp"
+
+#include <chrono>
+#include <condition_variable>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <mutex>
+#include <thread>
+
+using namespace evo_engine;
+using namespace std::chrono_literals;
+
+namespace {
+constexpr uint64_t kBlockingAssetHandle = 0xE701'0000'0000'0001ull;
+constexpr auto kBlockingAssetTypeName = "BlockingLoadAsset";
+constexpr auto kBlockingAssetExtension = ".evetestasset";
+constexpr uint64_t kStagedAssetHandle = 0xE701'0000'0000'0002ull;
+constexpr auto kStagedAssetTypeName = "StagedLoadAsset";
+constexpr auto kStagedAssetExtension = ".evestagedasset";
+
+struct BlockingLoadState {
+  std::mutex mutex;
+  std::condition_variable cv;
+  size_t load_count = 0;
+  bool load_started = false;
+  bool release_load = false;
+  std::weak_ptr<IAsset> first_loaded_asset;
+};
+
+BlockingLoadState& GetBlockingLoadState() {
+  static BlockingLoadState state;
+  return state;
+}
+
+void ResetBlockingLoadState() {
+  auto& state = GetBlockingLoadState();
+  std::lock_guard lock(state.mutex);
+  state.load_count = 0;
+  state.load_started = false;
+  state.release_load = false;
+  state.first_loaded_asset.reset();
+}
+
+bool WaitForBlockingLoadStarted(const std::chrono::milliseconds timeout) {
+  auto& state = GetBlockingLoadState();
+  std::unique_lock lock(state.mutex);
+  return state.cv.wait_for(lock, timeout, [&]() {
+    return state.load_started;
+  });
+}
+
+void ReleaseBlockingLoad() {
+  auto& state = GetBlockingLoadState();
+  {
+    std::lock_guard lock(state.mutex);
+    state.release_load = true;
+  }
+  state.cv.notify_all();
+}
+
+size_t GetBlockingLoadCount() {
+  auto& state = GetBlockingLoadState();
+  std::lock_guard lock(state.mutex);
+  return state.load_count;
+}
+
+std::shared_ptr<IAsset> GetFirstLoadedAsset() {
+  auto& state = GetBlockingLoadState();
+  std::lock_guard lock(state.mutex);
+  return state.first_loaded_asset.lock();
+}
+
+class ScopedBlockingLoadRelease {
+ public:
+  ~ScopedBlockingLoadRelease() {
+    ReleaseBlockingLoad();
+  }
+};
+
+class BlockingLoadAsset final : public IAsset {
+ protected:
+  bool LoadInternal(const std::filesystem::path&) override {
+    {
+      auto& state = GetBlockingLoadState();
+      std::lock_guard lock(state.mutex);
+      ++state.load_count;
+      if (state.first_loaded_asset.expired()) {
+        state.first_loaded_asset = GetSelf();
+      }
+      state.load_started = true;
+    }
+    GetBlockingLoadState().cv.notify_all();
+
+    auto& state = GetBlockingLoadState();
+    std::unique_lock lock(state.mutex);
+    state.cv.wait(lock, [&]() {
+      return state.release_load;
+    });
+    return true;
+  }
+};
+
+struct StagedLoadState {
+  std::mutex mutex;
+  std::condition_variable cv;
+  size_t sync_load_count = 0;
+  size_t payload_load_count = 0;
+  size_t finalize_count = 0;
+  bool payload_started = false;
+  bool release_payload = false;
+  bool payload_ran_on_asset_io = false;
+  bool finalize_ran_on_main_thread = false;
+};
+
+struct StagedLoadSnapshot {
+  size_t sync_load_count = 0;
+  size_t payload_load_count = 0;
+  size_t finalize_count = 0;
+  bool payload_started = false;
+  bool release_payload = false;
+  bool payload_ran_on_asset_io = false;
+  bool finalize_ran_on_main_thread = false;
+};
+
+StagedLoadState& GetStagedLoadState() {
+  static StagedLoadState state;
+  return state;
+}
+
+void ResetStagedLoadState() {
+  auto& state = GetStagedLoadState();
+  std::lock_guard lock(state.mutex);
+  state.sync_load_count = 0;
+  state.payload_load_count = 0;
+  state.finalize_count = 0;
+  state.payload_started = false;
+  state.release_payload = false;
+  state.payload_ran_on_asset_io = false;
+  state.finalize_ran_on_main_thread = false;
+}
+
+bool WaitForStagedPayloadStarted(const std::chrono::milliseconds timeout) {
+  auto& state = GetStagedLoadState();
+  std::unique_lock lock(state.mutex);
+  return state.cv.wait_for(lock, timeout, [&]() {
+    return state.payload_started;
+  });
+}
+
+bool WaitForStagedPayloadStartedWhilePumping(const std::chrono::milliseconds timeout) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    AssetManager::ExecuteMainThreadAssetTasks(1);
+    Jobs::ExecuteMainThreadJobs(1);
+    if (WaitForStagedPayloadStarted(10ms)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void ReleaseStagedPayload() {
+  auto& state = GetStagedLoadState();
+  {
+    std::lock_guard lock(state.mutex);
+    state.release_payload = true;
+  }
+  state.cv.notify_all();
+}
+
+StagedLoadSnapshot SnapshotStagedLoadState() {
+  auto& state = GetStagedLoadState();
+  std::lock_guard lock(state.mutex);
+  StagedLoadSnapshot snapshot;
+  snapshot.sync_load_count = state.sync_load_count;
+  snapshot.payload_load_count = state.payload_load_count;
+  snapshot.finalize_count = state.finalize_count;
+  snapshot.payload_started = state.payload_started;
+  snapshot.release_payload = state.release_payload;
+  snapshot.payload_ran_on_asset_io = state.payload_ran_on_asset_io;
+  snapshot.finalize_ran_on_main_thread = state.finalize_ran_on_main_thread;
+  return snapshot;
+}
+
+class ScopedStagedPayloadRelease {
+ public:
+  ~ScopedStagedPayloadRelease() {
+    ReleaseStagedPayload();
+  }
+};
+
+class StagedLoadPayload final : public StagedAssetLoadPayload {
+ public:
+  int value = 42;
+};
+
+class StagedLoadAsset final : public IAsset {
+ protected:
+  bool LoadInternal(const std::filesystem::path&) override {
+    auto& state = GetStagedLoadState();
+    std::lock_guard lock(state.mutex);
+    ++state.sync_load_count;
+    return true;
+  }
+
+  [[nodiscard]] bool SupportsStagedLoading() const override {
+    return true;
+  }
+
+  [[nodiscard]] std::shared_ptr<StagedAssetLoadPayload> LoadStagedPayloadInternal(
+      const std::filesystem::path&) const override {
+    {
+      auto& state = GetStagedLoadState();
+      std::lock_guard lock(state.mutex);
+      ++state.payload_load_count;
+      state.payload_started = true;
+      state.payload_ran_on_asset_io = Jobs::IsExecutorThread(JobExecutorType::AssetIo);
+    }
+    GetStagedLoadState().cv.notify_all();
+
+    auto& state = GetStagedLoadState();
+    std::unique_lock lock(state.mutex);
+    state.cv.wait(lock, [&]() {
+      return state.release_payload;
+    });
+    return std::make_shared<StagedLoadPayload>();
+  }
+
+  bool ApplyStagedPayloadInternal(const std::filesystem::path&,
+                                  const std::shared_ptr<StagedAssetLoadPayload>& payload) override {
+    const auto staged_payload = std::dynamic_pointer_cast<StagedLoadPayload>(payload);
+    auto& state = GetStagedLoadState();
+    std::lock_guard lock(state.mutex);
+    ++state.finalize_count;
+    state.finalize_ran_on_main_thread = Jobs::IsMainThread();
+    return staged_payload && staged_payload->value == 42;
+  }
+};
+
+class TempProject {
+ public:
+  TempProject() {
+    const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    root_ = std::filesystem::temp_directory_path() / ("EvoEngineAssetManagerTest_" + std::to_string(now));
+    std::filesystem::create_directories(AssetsPath());
+  }
+
+  ~TempProject() {
+    std::error_code error;
+    std::filesystem::remove_all(root_, error);
+  }
+
+  [[nodiscard]] std::filesystem::path ProjectPath() const {
+    return root_ / "AssetManagerTest.eveproj";
+  }
+
+  [[nodiscard]] std::filesystem::path AssetsPath() const {
+    return root_ / "Assets";
+  }
+
+ private:
+  std::filesystem::path root_;
+};
+
+void WriteBlockingAssetFixture(const TempProject& project) {
+  const auto asset_path = project.AssetsPath() / ("Coalesced" + std::string(kBlockingAssetExtension));
+  {
+    std::ofstream asset_file(asset_path);
+    asset_file << "test asset payload";
+  }
+
+  const auto metadata_path = asset_path.string() + ".evefilemeta";
+  std::ofstream metadata_file(metadata_path);
+  metadata_file << "asset_extension_: " << kBlockingAssetExtension << "\n";
+  metadata_file << "asset_file_name_: Coalesced\n";
+  metadata_file << "asset_type_name_: " << kBlockingAssetTypeName << "\n";
+  metadata_file << "asset_handle_: " << kBlockingAssetHandle << "\n";
+}
+
+void WriteStagedAssetFixture(const TempProject& project) {
+  const auto asset_path = project.AssetsPath() / ("Staged" + std::string(kStagedAssetExtension));
+  {
+    std::ofstream asset_file(asset_path);
+    asset_file << "staged asset payload";
+  }
+
+  const auto metadata_path = asset_path.string() + ".evefilemeta";
+  std::ofstream metadata_file(metadata_path);
+  metadata_file << "asset_extension_: " << kStagedAssetExtension << "\n";
+  metadata_file << "asset_file_name_: Staged\n";
+  metadata_file << "asset_type_name_: " << kStagedAssetTypeName << "\n";
+  metadata_file << "asset_handle_: " << kStagedAssetHandle << "\n";
+}
+
+ApplicationInitializationSettings TestApplicationSettings(const TempProject& project) {
+  ApplicationInitializationSettings settings;
+  settings.project_path = project.ProjectPath();
+  settings.load_default_resources = false;
+  settings.load_project_start_scene = false;
+  settings.enable_runtime_packages = false;
+  return settings;
+}
+}  // namespace
+
+TEST(AssetManager, BlockingAccessJoinsInFlightSynchronousProjectLoad) {
+  ResetBlockingLoadState();
+  TempProject project;
+  WriteBlockingAssetFixture(project);
+
+  Application app;
+  app.RegisterAsset<BlockingLoadAsset>(kBlockingAssetTypeName, {kBlockingAssetExtension});
+
+  std::exception_ptr project_load_exception;
+  std::thread project_load_thread([&]() {
+    try {
+      ApplicationContextScope scope(app);
+      app.Initialize(TestApplicationSettings(project));
+    } catch (...) {
+      project_load_exception = std::current_exception();
+      ReleaseBlockingLoad();
+    }
+  });
+
+  const bool load_started = WaitForBlockingLoadStarted(5s);
+  if (!load_started) {
+    ReleaseBlockingLoad();
+    if (project_load_thread.joinable()) {
+      project_load_thread.join();
+    }
+    if (project_load_exception) {
+      std::rethrow_exception(project_load_exception);
+    }
+    FAIL() << "Timed out waiting for the fixture asset to enter LoadInternal().";
+  }
+  ScopedBlockingLoadRelease release_on_exit;
+
+  auto instant_access = std::async(std::launch::async, [&]() {
+    ApplicationContextScope scope(app);
+    return AssetManager::GetAsset<BlockingLoadAsset>(Handle(kBlockingAssetHandle));
+  });
+
+  EXPECT_EQ(instant_access.wait_for(100ms), std::future_status::timeout);
+
+  ReleaseBlockingLoad();
+  std::shared_ptr<BlockingLoadAsset> instant_asset;
+  std::exception_ptr instant_access_exception;
+  try {
+    instant_asset = instant_access.get();
+  } catch (...) {
+    instant_access_exception = std::current_exception();
+  }
+
+  if (project_load_thread.joinable()) {
+    project_load_thread.join();
+  }
+  if (project_load_exception) {
+    std::rethrow_exception(project_load_exception);
+  }
+  if (instant_access_exception) {
+    std::rethrow_exception(instant_access_exception);
+  }
+
+  ASSERT_NE(instant_asset, nullptr);
+  EXPECT_EQ(GetBlockingLoadCount(), 1);
+  EXPECT_EQ(instant_asset, GetFirstLoadedAsset());
+
+  const auto later_asset = AssetManager::GetAsset<BlockingLoadAsset>(Handle(kBlockingAssetHandle));
+  EXPECT_EQ(later_asset, instant_asset);
+}
+
+TEST(AssetManager, AsyncStagedLoadSeparatesAssetIoFromMainThreadFinalization) {
+  ResetStagedLoadState();
+  TempProject project;
+  WriteStagedAssetFixture(project);
+
+  Application app;
+  ApplicationContextScope scope(app);
+  app.RegisterAsset<StagedLoadAsset>(kStagedAssetTypeName, {kStagedAssetExtension});
+  auto settings = TestApplicationSettings(project);
+  settings.load_project_assets = false;
+  app.Initialize(settings);
+
+  auto asset_future = AssetManager::GetAssetFuture<StagedLoadAsset>(Handle(kStagedAssetHandle));
+  const auto initial_snapshot = AssetManager::GetAssetLoadSnapshot();
+  EXPECT_EQ(initial_snapshot.total, 1);
+  EXPECT_TRUE(initial_snapshot.Active());
+
+  const bool payload_started = WaitForStagedPayloadStartedWhilePumping(5s);
+  if (!payload_started) {
+    ReleaseStagedPayload();
+    FAIL() << "Timed out waiting for staged asset payload loading to start.";
+  }
+  ScopedStagedPayloadRelease release_on_exit;
+
+  auto state_before_finalize = SnapshotStagedLoadState();
+  EXPECT_EQ(state_before_finalize.sync_load_count, 0);
+  EXPECT_EQ(state_before_finalize.payload_load_count, 1);
+  EXPECT_EQ(state_before_finalize.finalize_count, 0);
+
+  ReleaseStagedPayload();
+  const auto asset = asset_future.get();
+  ASSERT_NE(asset, nullptr);
+
+  const auto state_after_finalize = SnapshotStagedLoadState();
+  const auto final_snapshot = AssetManager::GetAssetLoadSnapshot();
+  EXPECT_FALSE(final_snapshot.Active());
+  EXPECT_EQ(final_snapshot.total, 1);
+  EXPECT_EQ(final_snapshot.completed, 1);
+  EXPECT_EQ(state_after_finalize.sync_load_count, 0);
+  EXPECT_EQ(state_after_finalize.payload_load_count, 1);
+  EXPECT_EQ(state_after_finalize.finalize_count, 1);
+  EXPECT_TRUE(state_after_finalize.payload_ran_on_asset_io);
+  EXPECT_TRUE(state_after_finalize.finalize_ran_on_main_thread);
+
+  const auto later_asset = AssetManager::GetAsset<StagedLoadAsset>(Handle(kStagedAssetHandle));
+  EXPECT_EQ(later_asset, asset);
+}

--- a/EvoEngine_Tests/Core/TaskRuntimeTest.cpp
+++ b/EvoEngine_Tests/Core/TaskRuntimeTest.cpp
@@ -1,0 +1,109 @@
+#include "TaskRuntime.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+using namespace evo_engine;
+
+namespace {
+TaskRuntimeSettings TestRuntimeSettings() {
+  TaskRuntimeSettings settings;
+  settings.worker_thread_size = 2;
+  settings.asset_io_thread_size = 1;
+  settings.render_thread_size = 1;
+  settings.background_thread_size = 1;
+  return settings;
+}
+}  // namespace
+
+TEST(TaskRuntime, ExecutesDependencyGraphInOrder) {
+  TaskRuntime runtime;
+  runtime.Initialize(TestRuntimeSettings());
+
+  std::mutex order_mutex;
+  std::vector<int> order;
+  const auto dependency = runtime.Schedule([&]() {
+    std::lock_guard lock(order_mutex);
+    order.emplace_back(1);
+  });
+  const auto dependent = runtime.Schedule({dependency}, [&]() {
+    std::lock_guard lock(order_mutex);
+    order.emplace_back(2);
+  });
+
+  runtime.Wait(dependent);
+  ASSERT_EQ(order.size(), 2);
+  EXPECT_EQ(order[0], 1);
+  EXPECT_EQ(order[1], 2);
+}
+
+TEST(TaskRuntime, RunsMainThreadTasksOnWaitingMainThread) {
+  TaskRuntime runtime;
+  runtime.Initialize(TestRuntimeSettings());
+
+  const auto main_thread_id = std::this_thread::get_id();
+  std::thread::id executed_thread_id;
+  TaskOptions options;
+  options.executor = TaskExecutorType::MainThread;
+  options.affinity = ThreadAffinity::MainThread;
+
+  const auto task = runtime.Schedule({}, options, [&]() {
+    executed_thread_id = std::this_thread::get_id();
+  });
+
+  runtime.Wait(task);
+  EXPECT_EQ(executed_thread_id, main_thread_id);
+}
+
+TEST(TaskRuntime, RunsNamedServiceExecutors) {
+  TaskRuntime runtime;
+  runtime.Initialize(TestRuntimeSettings());
+
+  std::atomic_bool asset_io_executed = false;
+  std::atomic_bool render_executed = false;
+  std::atomic_bool background_executed = false;
+
+  TaskOptions asset_options;
+  asset_options.executor = TaskExecutorType::AssetIo;
+  const auto asset_task = runtime.Schedule({}, asset_options, [&]() {
+    asset_io_executed = runtime.IsExecutorThread(TaskExecutorType::AssetIo);
+  });
+
+  TaskOptions render_options;
+  render_options.executor = TaskExecutorType::Render;
+  const auto render_task = runtime.Schedule({}, render_options, [&]() {
+    render_executed = runtime.IsExecutorThread(TaskExecutorType::Render);
+  });
+
+  TaskOptions background_options;
+  background_options.executor = TaskExecutorType::Background;
+  const auto background_task = runtime.Schedule({}, background_options, [&]() {
+    background_executed = runtime.IsExecutorThread(TaskExecutorType::Background);
+  });
+
+  runtime.Wait(asset_task);
+  runtime.Wait(render_task);
+  runtime.Wait(background_task);
+
+  EXPECT_TRUE(asset_io_executed);
+  EXPECT_TRUE(render_executed);
+  EXPECT_TRUE(background_executed);
+}
+
+TEST(TaskRuntime, PropagatesTaskExceptionsOnWait) {
+  TaskRuntime runtime;
+  runtime.Initialize(TestRuntimeSettings());
+
+  const auto task = runtime.Schedule([]() {
+    throw std::runtime_error("task failure");
+  });
+
+  EXPECT_THROW(runtime.Wait(task), std::runtime_error);
+  const auto stats = runtime.GetStats();
+  EXPECT_EQ(stats.failed_task_size, 1);
+}

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ Services can extend rendering through `RenderLayer` callbacks for shadow maps, d
 
 ### Jobs, Input, and Time
 
-The SDK job system supports scheduled and immediate parallel work. ECS iteration helpers use jobs to process chunks in parallel. Input is routed from GLFW callbacks through the engine input system and layer event hooks. Timing utilities track frame delta time, fixed timestep state, and update counters.
+The SDK job system supports scheduled and immediate parallel work. ECS iteration helpers use jobs to process chunks in parallel. The runtime owns a general worker pool plus named service executors for main-thread callbacks, asset IO, rendering work, and background tasks. `JobSystem` and `Jobs` remain compatibility facades over this engine-owned `TaskRuntime` boundary so backend experiments can happen behind the same API.
+
+Interactive project asset loading now dispatches scanned assets as an `AssetManager` batch instead of resolving one pending asset per frame. The asset-service path owns per-handle in-flight state, progress snapshots, and blocking sync access, so concurrent requests wait for the first loader instead of creating duplicate asset instances. Assets can opt into staged async loading by producing a CPU-only payload on the asset-IO executor and applying it later on the bounded main-thread finalization lane. SDK staged assets now include `Texture2D`, shader/JSON source assets, scene and native prefab YAML, strands, point clouds, and the SDK YAML-backed render assets that deserialize through the default `IAsset` path. Legacy non-staged paths, especially imported model prefab formats that still run through Assimp and create engine objects during import, continue to finalize on the main thread. `ApplicationInitializationSettings::load_project_assets` can disable headless project asset preloading for tests and tools that want to request assets explicitly. Input is routed from GLFW callbacks through the engine input system and layer event hooks. Timing utilities track frame delta time, fixed timestep state, and update counters.
 
 ### Applications
 
@@ -186,7 +188,7 @@ python Scripts/format_cpp.py
 python Scripts/format_cpp.py --check
 ```
 
-`python Scripts/test.py` is the local render test runner. By default it builds and runs the render/GPU test target, writes the latest visual artifact under `out/test-artifacts/latest`, and reports PSNR/SSIM for the golden-image comparison. Use `--all` to run every CTest test in the local build tree.
+`python Scripts/test.py` is the local render test runner. By default it builds the `EvoEngine_RenderTests` aggregate target and runs render/GPU-labeled tests, including the render golden-image comparison and a `DemoApp` executable smoke test that waits for the rendering demo project to finish loading, enters play mode, and renders 100 frames. Visual artifacts are written under `out/test-artifacts/latest`, and PSNR/SSIM are reported for the golden-image comparison. Use `--all` to run every CTest test in the local build tree.
 
 GitHub Actions are limited to repository-wide format checks and platform compilation checks. Rendering tests are intentionally local-only because they require a Vulkan-capable GPU environment and produce visual artifacts for inspection.
 
@@ -278,6 +280,8 @@ When adding new work:
 Runtime packages live under `EvoEngine_Packages`. The package CMake entry scans package folders automatically, reads optional metadata from `PackageInfo.cmake`, creates an `EVOENGINE_ENABLE_<Name>_PACKAGE` option, and builds a shared library target named `<Name>Package` by default. Disable individual package targets with `EVOENGINE_ENABLE_<Name>_PACKAGE=OFF` when a build should skip them.
 
 Apps do not load runtime packages by default. Set `ApplicationInitializationSettings::enable_runtime_packages = true` and add names to `ApplicationInitializationSettings::startup_runtime_packages`, or call `PackageManager::Load/LoadAll` from runtime/editor tooling when a workflow needs additional package functionality.
+
+Headless tools and focused tests that only need project scanning or asset metadata can set `ApplicationInitializationSettings::load_default_resources = false` and `ApplicationInitializationSettings::load_project_start_scene = false` to avoid creating render defaults or attaching a scene during initialization.
 
 Package dependencies are declared with `EVOENGINE_PACKAGE_DEPENDS` in `PackageInfo.cmake`. CMake builds dependencies first and emits a sidecar `.evepackage` manifest beside each package binary so the runtime can discover and load dependencies before opening a package DLL/shared library.
 


### PR DESCRIPTION
﻿## Summary

This PR overhauls EvoEngine's job runtime and asynchronous asset-loading path as groundwork for future GPU-service/render-thread work.

## What changed

- Added `TaskRuntime` as the engine-owned execution layer with worker, asset IO, render, background, and main-thread lanes.
- Kept the existing `Jobs` / `JobSystem` API working over the new runtime.
- Added asynchronous asset loading with per-handle in-flight coalescing, progress snapshots, and blocking access that joins existing loads instead of racing duplicate work.
- Added staged asset loading so CPU/disk work can run off-thread while asset finalization stays on the main thread.
- Converted SDK asset types to opt into staged loading where safe.
- Updated project asset loading to dispatch batches through the asset service and updated the loading popup progress path.
- Added an automated DemoApp smoke test that waits for project load, enters play mode, and runs 100 frames.
- Documented local branch task tracking and updated test documentation.

## Validation

- `git diff --check`
- `python Scripts\test.py --all --config RelWithDebInfo --no-configure`

All 8 local CTest tests passed, including `TaskRuntime`, `AssetManager`, Python render capture, and `DemoApp.PlayLoadedScene100Frames`.

## Notes

Render/GPU tests remain local per the repo's current test ownership. This PR intentionally does not implement the future GPU service/render-thread plan; that work is intended for a follow-up branch.
