### PR TITLE
Add editor profiler panel

### DIFF
--- a/EvoEngine_App/include/AppBootstrap.hpp
+++ b/EvoEngine_App/include/AppBootstrap.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "Application.hpp"
+#include "EditorLayer.hpp"
+#include "ImGuiLayer.hpp"
+#include "RenderLayer.hpp"
+#include "WindowLayer.hpp"
+
+#include <stdexcept>
+#include <string>
+
+namespace evo_engine {
+
+[[nodiscard]] inline ApplicationMode ParseApplicationModeName(const std::string& mode_name) {
+  if (mode_name == "Editor" || mode_name == "editor") {
+    return ApplicationMode::Editor;
+  }
+  if (mode_name == "Player" || mode_name == "player") {
+    return ApplicationMode::Player;
+  }
+  if (mode_name == "Headless" || mode_name == "headless") {
+    return ApplicationMode::Headless;
+  }
+  throw std::invalid_argument("Unknown application mode: " + mode_name);
+}
+
+[[nodiscard]] inline const char* GetApplicationModeName(const ApplicationMode mode) {
+  switch (mode) {
+    case ApplicationMode::Editor:
+      return "Editor";
+    case ApplicationMode::Player:
+      return "Player";
+    case ApplicationMode::Headless:
+      return "Headless";
+  }
+  return "Editor";
+}
+
+[[nodiscard]] inline const char* GetApplicationModeArgument(const ApplicationMode mode) {
+  switch (mode) {
+    case ApplicationMode::Editor:
+      return "--editor";
+    case ApplicationMode::Player:
+      return "--player";
+    case ApplicationMode::Headless:
+      return "--headless";
+  }
+  return "--editor";
+}
+
+inline bool ConsumeApplicationModeArgument(const int argc, char** argv, int& arg_index, ApplicationMode& mode) {
+  const std::string argument = argv[arg_index] ? argv[arg_index] : "";
+  if (argument == "--editor") {
+    mode = ApplicationMode::Editor;
+    return true;
+  }
+  if (argument == "--player") {
+    mode = ApplicationMode::Player;
+    return true;
+  }
+  if (argument == "--headless") {
+    mode = ApplicationMode::Headless;
+    return true;
+  }
+  if (argument == "--application-mode" || argument == "--mode") {
+    if (arg_index + 1 >= argc) {
+      throw std::invalid_argument(argument + " requires Editor, Player, or Headless.");
+    }
+    mode = ParseApplicationModeName(argv[++arg_index]);
+    return true;
+  }
+  return false;
+}
+
+[[nodiscard]] inline ApplicationMode ParseApplicationModeArguments(const int argc, char** argv) {
+  auto mode = ApplicationMode::Editor;
+  for (int arg_index = 1; arg_index < argc; ++arg_index) {
+    if (!ConsumeApplicationModeArgument(argc, argv, arg_index, mode)) {
+      throw std::invalid_argument("Unknown application argument: " +
+                                  std::string(argv[arg_index] ? argv[arg_index] : ""));
+    }
+  }
+  return mode;
+}
+
+inline void ApplyApplicationModeDefaults(ApplicationInitializationSettings& settings) {
+  if (settings.application_mode != ApplicationMode::Editor) {
+    settings.use_custom_title_bar = false;
+  }
+  if (settings.application_mode == ApplicationMode::Headless) {
+    settings.enable_docking = false;
+    settings.enable_viewport = false;
+    settings.load_default_resources = false;
+    settings.load_project_assets = false;
+  }
+}
+
+inline void PushWindowAndUiLayers(const ApplicationMode mode) {
+  if (mode == ApplicationMode::Headless) {
+    return;
+  }
+  ApplicationContext::Get().PushLayer<WindowLayer>("Window Layer");
+  if (mode == ApplicationMode::Editor) {
+    ApplicationContext::Get().PushLayer<ImGuiLayer>("ImGui Layer");
+    ApplicationContext::Get().PushLayer<EditorLayer>("Editor Layer");
+  }
+}
+
+inline void PushStandardApplicationLayers(const ApplicationMode mode) {
+  if (mode == ApplicationMode::Headless) {
+    return;
+  }
+  ApplicationContext::Get().PushLayer<RenderLayer>("Render Layer");
+  PushWindowAndUiLayers(mode);
+}
+
+}  // namespace evo_engine

--- a/EvoEngine_App/src/DemoApp.cpp
+++ b/EvoEngine_App/src/DemoApp.cpp
@@ -1,3 +1,4 @@
+#include "AppBootstrap.hpp"
 #include "Application.hpp"
 #include "AssetManager.hpp"
 #include "Camera.hpp"
@@ -30,6 +31,7 @@ enum class DemoAppRunMode { Normal, SmokeTest, EditorScreenshot };
 
 struct DemoAppRuntimeConfig {
   DemoAppRunMode mode = DemoAppRunMode::Normal;
+  ApplicationMode application_mode = ApplicationMode::Editor;
   DemoSetup demo_setup = DemoSetup::Rendering;
   size_t frames_after_play = 100;
   size_t warmup_frames = 30;
@@ -42,18 +44,36 @@ struct DemoAppRuntimeConfig {
   std::filesystem::path done_file;
 };
 
-std::optional<std::filesystem::path> FindRunConfigPath(const int argc, char** argv) {
+struct DemoAppCommandLine {
+  std::optional<std::filesystem::path> run_config_path;
+  std::optional<ApplicationMode> application_mode;
+};
+
+DemoAppCommandLine ParseCommandLine(const int argc, char** argv) {
+  DemoAppCommandLine command_line;
   for (int arg_index = 1; arg_index < argc; ++arg_index) {
     const std::string argument = argv[arg_index] ? argv[arg_index] : "";
     if (argument == "--run-config") {
       if (arg_index + 1 >= argc) {
         throw std::invalid_argument("--run-config requires a path.");
       }
-      return std::filesystem::absolute(argv[arg_index + 1]);
+      command_line.run_config_path = std::filesystem::absolute(argv[++arg_index]);
+    } else {
+      auto mode = command_line.application_mode.value_or(ApplicationMode::Editor);
+      if (!ConsumeApplicationModeArgument(argc, argv, arg_index, mode)) {
+        throw std::invalid_argument("Unknown DemoApp argument: " + argument);
+      }
+      command_line.application_mode = mode;
     }
-    throw std::invalid_argument("Unknown DemoApp argument: " + argument);
   }
+  return command_line;
+}
 
+std::optional<std::filesystem::path> FindRunConfigPath(const DemoAppCommandLine& command_line, const int argc,
+                                                       char** argv) {
+  if (command_line.run_config_path) {
+    return command_line.run_config_path;
+  }
   std::vector<std::filesystem::path> candidates;
   if (argc > 0 && argv[0]) {
     candidates.emplace_back(std::filesystem::absolute(argv[0]).parent_path() / "DemoApp.run.yaml");
@@ -99,6 +119,9 @@ DemoAppRuntimeConfig LoadRunConfig(const std::filesystem::path& path) {
       throw std::invalid_argument("Unknown mode value: " + mode_name);
     }
   }
+  if (const auto application_mode = root["application_mode"]) {
+    config.application_mode = ParseApplicationModeName(application_mode.as<std::string>());
+  }
   if (const auto demo_setup = root["demo_setup"]) {
     config.demo_setup = ParseDemoSetup(demo_setup.as<std::string>());
   }
@@ -143,7 +166,8 @@ int FailSmokeTest(Application& application, const std::string& reason) {
 
 int RunSmokeTest(const DemoAppRuntimeConfig& config) {
   auto& application = ApplicationContext::Get();
-  application.Start(false);
+  const bool expect_player_autoplay = config.application_mode == ApplicationMode::Player;
+  application.Start(expect_player_autoplay);
 
   size_t load_frame_count = 0;
   while (!ProjectManager::IsProjectIdle()) {
@@ -164,9 +188,15 @@ int RunSmokeTest(const DemoAppRuntimeConfig& config) {
   }
 
   const auto loaded_frame = Platform::GetFrameCount();
-  application.Play();
-  if (!application.IsPlaying()) {
-    return FailSmokeTest(application, "application did not enter play mode");
+  if (expect_player_autoplay) {
+    if (!application.IsPlaying()) {
+      return FailSmokeTest(application, "player mode did not enter play mode automatically");
+    }
+  } else {
+    application.Play();
+    if (!application.IsPlaying()) {
+      return FailSmokeTest(application, "application did not enter play mode");
+    }
   }
 
   const auto play_start_frame = Platform::GetFrameCount();
@@ -426,27 +456,35 @@ int main(const int argc, char** argv) {
   bool initialized = false;
   bool automated_run = false;
   try {
-    const auto run_config_path = FindRunConfigPath(argc, argv);
+    const auto command_line = ParseCommandLine(argc, argv);
+    const auto run_config_path = FindRunConfigPath(command_line, argc, argv);
     std::optional<DemoAppRuntimeConfig> runtime_config;
     if (run_config_path) {
       runtime_config = LoadRunConfig(*run_config_path);
     }
+    if (runtime_config && command_line.application_mode) {
+      runtime_config->application_mode = *command_line.application_mode;
+    }
     const auto demo_setup = runtime_config ? runtime_config->demo_setup : DemoSetup::Rendering;
+    auto application_mode = command_line.application_mode.value_or(ApplicationMode::Editor);
+    if (runtime_config) {
+      application_mode = runtime_config->mode == DemoAppRunMode::EditorScreenshot ? ApplicationMode::Editor
+                                                                                  : runtime_config->application_mode;
+    }
 
-    ApplicationContext::Get().PushLayer<RenderLayer>("Render Layer");
-    ApplicationContext::Get().PushLayer<WindowLayer>("Window Layer");
-    ApplicationContext::Get().PushLayer<ImGuiLayer>("ImGui Layer");
-    ApplicationContext::Get().PushLayer<EditorLayer>("Editor Layer");
+    PushStandardApplicationLayers(application_mode);
 #ifdef PHYSX_PHYSICS_SERVICE
     ApplicationContext::Get().PushLayer<PhysicsLayer>();
 #endif
 
     ApplicationInitializationSettings application_info;
     SetupDemoScene(demo_setup, application_info);
+    application_info.application_mode = application_mode;
     if (runtime_config && runtime_config->mode == DemoAppRunMode::EditorScreenshot) {
       application_info.default_window_size = {runtime_config->screenshot_width, runtime_config->screenshot_height};
     }
     application_info.use_custom_title_bar = true;
+    ApplyApplicationModeDefaults(application_info);
 
     ApplicationContext::Get().Initialize(application_info);
     initialized = true;

--- a/EvoEngine_App/src/DigitalAgricultureApp.cpp
+++ b/EvoEngine_App/src/DigitalAgricultureApp.cpp
@@ -7,21 +7,19 @@
 #  include <CUDAModule.hpp>
 #  include <RayTracerLayer.hpp>
 #endif
+#include "AppBootstrap.hpp"
 #include "ClassRegistry.hpp"
 #include "PathUtils.hpp"
 #include "Times.hpp"
 
 #include "ProjectManager.hpp"
 
-#include "EditorLayer.hpp"
-#include "ImGuiLayer.hpp"
-#include "RenderLayer.hpp"
-#include "WindowLayer.hpp"
 using namespace evo_engine;
 void EngineSetup();
 
-int main() {
+int main(const int argc, char** argv) {
   Application application;
+  const auto application_mode = ParseApplicationModeArguments(argc, argv);
   auto resource_folder_path = path_utils::FindAncestorChildPath("Resources", std::filesystem::current_path(), 8);
   if (resource_folder_path.empty()) {
     resource_folder_path = path_utils::NormalizeAbsolutePath("Resources");
@@ -58,33 +56,31 @@ int main() {
 
   EngineSetup();
 
-  ApplicationContext::Get().PushLayer<RenderLayer>("Render Layer");
+  if (application_mode != ApplicationMode::Headless) {
+    ApplicationContext::Get().PushLayer<RenderLayer>("Render Layer");
 #ifdef CUDA_MODULE_SERVICE
-  ApplicationContext::Get().PushLayer<RayTracerLayer>("Ray Tracer Layer");
+    ApplicationContext::Get().PushLayer<RayTracerLayer>("Ray Tracer Layer");
 #endif
-  ApplicationContext::Get().PushLayer<WindowLayer>("Window Layer");
-  ApplicationContext::Get().PushLayer<ImGuiLayer>("ImGui Layer");
-  ApplicationContext::Get().PushLayer<EditorLayer>("Editor Layer");
+    PushWindowAndUiLayers(application_mode);
+  }
 
   ApplicationInitializationSettings application_configs;
+  application_configs.application_mode = application_mode;
   application_configs.application_name = "DigitalAgriculture";
   application_configs.project_path =
       std::filesystem::absolute(resource_folder_path / "DigitalAgricultureProject" / "test.eveproj");
   application_configs.enable_runtime_packages = true;
   application_configs.use_custom_title_bar = true;
   application_configs.startup_runtime_packages = {"DigitalAgriculture"};
+  ApplyApplicationModeDefaults(application_configs);
   ApplicationContext::Get().Initialize(application_configs);
-
-#ifdef CUDA_MODULE_SERVICE
-
-  auto ray_tracer_layer = ApplicationContext::Get().GetLayer<RayTracerLayer>();
-#endif
 
   // adjust default camera speed
   const auto editor_layer = ApplicationContext::Get().GetLayer<EditorLayer>();
-  editor_layer->velocity = 2.f;
-  editor_layer->default_scene_camera_position = glm::vec3(1.124, 0.218, 14.089);
-  const auto render_layer = ApplicationContext::Get().GetLayer<RenderLayer>();
+  if (editor_layer) {
+    editor_layer->velocity = 2.f;
+    editor_layer->default_scene_camera_position = glm::vec3(1.124, 0.218, 14.089);
+  }
 #pragma region Engine Loop
   ApplicationContext::Get().Start();
   ApplicationContext::Get().Run();

--- a/EvoEngine_App/src/EcoSysLabApp.cpp
+++ b/EvoEngine_App/src/EcoSysLabApp.cpp
@@ -3,6 +3,7 @@
 //
 #include <Application.hpp>
 
+#include "AppBootstrap.hpp"
 #include "ClassRegistry.hpp"
 #include "PathUtils.hpp"
 #include "PostProcessingStack.hpp"
@@ -10,15 +11,12 @@
 
 #include "ProjectManager.hpp"
 
-#include "EditorLayer.hpp"
-#include "ImGuiLayer.hpp"
-#include "RenderLayer.hpp"
-#include "WindowLayer.hpp"
 using namespace evo_engine;
 void EngineSetup();
 
-int main() {
+int main(const int argc, char** argv) {
   Application application;
+  const auto application_mode = ParseApplicationModeArguments(argc, argv);
   auto resource_folder_path = path_utils::FindAncestorChildPath("Resources", std::filesystem::current_path(), 8);
   if (resource_folder_path.empty()) {
     resource_folder_path = path_utils::NormalizeAbsolutePath("Resources");
@@ -55,21 +53,20 @@ int main() {
 
   EngineSetup();
 
-  ApplicationContext::Get().PushLayer<RenderLayer>("Render Layer");
-  ApplicationContext::Get().PushLayer<WindowLayer>("Window Layer");
-  ApplicationContext::Get().PushLayer<ImGuiLayer>("ImGui Layer");
-  ApplicationContext::Get().PushLayer<EditorLayer>("Editor Layer");
+  PushStandardApplicationLayers(application_mode);
 
 #ifdef PHYSX_PHYSICS_SERVICE
   ApplicationContext::Get().PushLayer<PhysicsLayer>();
 #endif
   ApplicationInitializationSettings application_configs;
+  application_configs.application_mode = application_mode;
   application_configs.application_name = "EcoSysLab";
   application_configs.project_path =
       std::filesystem::absolute(resource_folder_path / "EcoSysLabProject" / "test.eveproj");
   application_configs.enable_runtime_packages = true;
   application_configs.use_custom_title_bar = true;
   application_configs.startup_runtime_packages = {"EcoSysLab"};
+  ApplyApplicationModeDefaults(application_configs);
   ApplicationContext::Get().Initialize(application_configs);
 
 #ifdef PHYSX_PHYSICS_SERVICE
@@ -77,15 +74,16 @@ int main() {
 #endif
   // adjust default camera speed
   const auto editor_layer = ApplicationContext::Get().GetLayer<EditorLayer>();
-  editor_layer->velocity = 2.f;
-  auto& camera_settings = editor_layer->GetSceneCamera()->camera_settings;
-  camera_settings.use_clear_color = true;
-  camera_settings.clear_color = glm::vec4(1.f);
-  camera_settings.background_intensity = 3.f;
-  const auto post_processing_stack =
-      editor_layer->GetSceneCamera()->post_processing_stack_ref.Get<PostProcessingStack>();
-  post_processing_stack->enable_bloom = false;
-  auto render_layer = ApplicationContext::Get().GetLayer<RenderLayer>();
+  if (editor_layer) {
+    editor_layer->velocity = 2.f;
+    auto& camera_settings = editor_layer->GetSceneCamera()->camera_settings;
+    camera_settings.use_clear_color = true;
+    camera_settings.clear_color = glm::vec4(1.f);
+    camera_settings.background_intensity = 3.f;
+    const auto post_processing_stack =
+        editor_layer->GetSceneCamera()->post_processing_stack_ref.Get<PostProcessingStack>();
+    post_processing_stack->enable_bloom = false;
+  }
 #pragma region Engine Loop
   ApplicationContext::Get().Start();
   ApplicationContext::Get().Run();

--- a/EvoEngine_App/src/EvoEngineEditor.cpp
+++ b/EvoEngine_App/src/EvoEngineEditor.cpp
@@ -1,10 +1,8 @@
+#include "AppBootstrap.hpp"
 #include "Application.hpp"
 #include "EditorLayer.hpp"
-#include "ImGuiLayer.hpp"
 #include "PathUtils.hpp"
 #include "ProjectManager.hpp"
-#include "RenderLayer.hpp"
-#include "WindowLayer.hpp"
 
 #include <optional>
 #include <stdexcept>
@@ -19,22 +17,29 @@
 using namespace evo_engine;
 
 namespace {
-std::optional<std::filesystem::path> ParseProjectPath(const int argc, char** argv) {
+struct EditorCommandLine {
   std::optional<std::filesystem::path> project_path;
+  ApplicationMode application_mode = ApplicationMode::Editor;
+};
+
+EditorCommandLine ParseCommandLine(const int argc, char** argv) {
+  EditorCommandLine command_line;
   for (int arg_index = 1; arg_index < argc; ++arg_index) {
     const std::string argument = argv[arg_index] ? argv[arg_index] : "";
     if (argument == "--project" || argument == "-p") {
       if (arg_index + 1 >= argc) {
         throw std::invalid_argument(argument + " requires a project path.");
       }
-      project_path = std::filesystem::absolute(argv[++arg_index]);
-    } else if (!project_path) {
-      project_path = std::filesystem::absolute(argument);
+      command_line.project_path = std::filesystem::absolute(argv[++arg_index]);
+    } else if (ConsumeApplicationModeArgument(argc, argv, arg_index, command_line.application_mode)) {
+      continue;
+    } else if (!command_line.project_path) {
+      command_line.project_path = std::filesystem::absolute(argument);
     } else {
       throw std::invalid_argument("Unknown EvoEngineEditor argument: " + argument);
     }
   }
-  return project_path;
+  return command_line;
 }
 
 std::filesystem::path CurrentExecutablePath() {
@@ -89,7 +94,8 @@ int main(const int argc, char** argv) {
   Application application;
   bool initialized = false;
   try {
-    const auto project_path = ParseProjectPath(argc, argv);
+    const auto command_line = ParseCommandLine(argc, argv);
+    const auto& project_path = command_line.project_path;
     if (!project_path) {
       std::string error;
       if (!LaunchLauncherProcess(error)) {
@@ -103,18 +109,17 @@ int main(const int argc, char** argv) {
       return 1;
     }
 
-    ApplicationContext::Get().PushLayer<RenderLayer>("Render Layer");
-    ApplicationContext::Get().PushLayer<WindowLayer>("Window Layer");
-    ApplicationContext::Get().PushLayer<ImGuiLayer>("ImGui Layer");
-    ApplicationContext::Get().PushLayer<EditorLayer>("Editor Layer");
+    PushStandardApplicationLayers(command_line.application_mode);
 
     ApplicationInitializationSettings application_info{};
+    application_info.application_mode = command_line.application_mode;
     const auto launch_metadata = ProjectManager::LoadProjectLaunchMetadata(*project_path);
     application_info.application_name = launch_metadata.application_name;
     application_info.project_path = *project_path;
     application_info.use_custom_title_bar = true;
     application_info.startup_runtime_packages = launch_metadata.startup_runtime_packages;
     application_info.enable_runtime_packages = !application_info.startup_runtime_packages.empty();
+    ApplyApplicationModeDefaults(application_info);
     ApplicationContext::Get().Initialize(application_info);
     initialized = true;
 

--- a/EvoEngine_App/src/EvoEngineLauncher.cpp
+++ b/EvoEngine_App/src/EvoEngineLauncher.cpp
@@ -1,3 +1,4 @@
+#include "AppBootstrap.hpp"
 #include "Application.hpp"
 #include "AssetManager.hpp"
 #include "EditorTheme.hpp"
@@ -18,6 +19,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <unordered_map>
 #include <vector>
@@ -244,7 +246,8 @@ std::filesystem::path EditorExecutablePath() {
 #endif
 }
 
-bool LaunchEditorProcess(const std::filesystem::path& project_path, std::string& error) {
+bool LaunchEditorProcess(const std::filesystem::path& project_path, const ApplicationMode application_mode,
+                         std::string& error) {
   const auto editor_path = EditorExecutablePath();
   if (!std::filesystem::exists(editor_path)) {
     error = "Could not find EvoEngineEditor next to EvoEngineLauncher.";
@@ -252,8 +255,10 @@ bool LaunchEditorProcess(const std::filesystem::path& project_path, std::string&
   }
 
 #ifdef EVOENGINE_WINDOWS
-  std::wstring command_line =
-      L"\"" + editor_path.wstring() + L"\" --project \"" + std::filesystem::absolute(project_path).wstring() + L"\"";
+  const auto mode_argument = GetApplicationModeArgument(application_mode);
+  const std::wstring wide_mode_argument(mode_argument, mode_argument + std::strlen(mode_argument));
+  std::wstring command_line = L"\"" + editor_path.wstring() + L"\" --project \"" +
+                              std::filesystem::absolute(project_path).wstring() + L"\" " + wide_mode_argument;
   STARTUPINFOW startup_info{};
   startup_info.cb = sizeof(startup_info);
   PROCESS_INFORMATION process_info{};
@@ -267,8 +272,9 @@ bool LaunchEditorProcess(const std::filesystem::path& project_path, std::string&
   CloseHandle(process_info.hThread);
   return true;
 #else
-  const auto command =
-      "\"" + editor_path.string() + "\" --project \"" + std::filesystem::absolute(project_path).string() + "\" &";
+  const auto command = "\"" + editor_path.string() + "\" --project \"" +
+                       std::filesystem::absolute(project_path).string() + "\" " +
+                       GetApplicationModeArgument(application_mode) + " &";
   if (std::system(command.c_str()) != 0) {
     error = "Failed to launch EvoEngineEditor.";
     return false;
@@ -308,6 +314,10 @@ class LauncherLayer final : public ILayer {
     LoadRecentProjects();
     AppendRecentProjectCountTestLog();
     AppendPackageAvailabilityTestLog();
+    if (const char* launch_mode = std::getenv("EVOENGINE_LAUNCHER_TEST_APPLICATION_MODE")) {
+      selected_launch_mode_ = ParseApplicationModeName(launch_mode);
+    }
+    AppendLaunchModeTestLog();
     AppendTestLog("mode:hub");
     if (const char* open_project = std::getenv("EVOENGINE_LAUNCHER_TEST_OPEN_PROJECT")) {
       pending_test_open_project_ = open_project;
@@ -339,6 +349,7 @@ class LauncherLayer final : public ILayer {
   std::vector<AvailablePackageInfo> available_packages_;
   std::vector<std::string> selected_startup_runtime_packages_;
   launcher::PackageAvailability package_availability_;
+  ApplicationMode selected_launch_mode_ = ApplicationMode::Editor;
   std::unordered_map<std::string, std::shared_ptr<Texture2D>> title_bar_icons_;
   bool dock_layout_dirty_ = true;
   ImGuiID dock_space_id_ = 0;
@@ -528,6 +539,8 @@ class LauncherLayer final : public ILayer {
     if (!launch_error_.empty()) {
       ImGui::TextColored(ColorError(), "%s", launch_error_.c_str());
     }
+    DrawLaunchModeSelector(std::min(content_width, 320.0f));
+    ImGui::Spacing();
     ImGui::PushID("RecentOpenProject");
     FileUtils::OpenFile(
         "Open Project", "Project", {".eveproj"},
@@ -565,6 +578,36 @@ class LauncherLayer final : public ILayer {
       }
     }
     ImGui::EndChild();
+  }
+
+  void DrawLaunchModeSelector(const float width) {
+    ImGui::TextUnformatted("Start Mode");
+    ImGui::SetNextItemWidth(width);
+    if (ImGui::BeginCombo("##StartMode", GetApplicationModeName(selected_launch_mode_))) {
+      for (const auto mode : {ApplicationMode::Editor, ApplicationMode::Player, ApplicationMode::Headless}) {
+        const bool selected = selected_launch_mode_ == mode;
+        if (ImGui::Selectable(GetApplicationModeName(mode), selected)) {
+          selected_launch_mode_ = mode;
+          launch_error_.clear();
+          AppendLaunchModeTestLog();
+        }
+        if (selected) {
+          ImGui::SetItemDefaultFocus();
+        }
+      }
+      ImGui::EndCombo();
+    }
+    switch (selected_launch_mode_) {
+      case ApplicationMode::Editor:
+        ImGui::TextColored(ColorTextMuted(), "Open with editor UI and tooling.");
+        break;
+      case ApplicationMode::Player:
+        ImGui::TextColored(ColorTextMuted(), "Run the project scene without editor UI.");
+        break;
+      case ApplicationMode::Headless:
+        ImGui::TextColored(ColorTextMuted(), "Run without a window for automation/service use.");
+        break;
+    }
   }
 
   bool DrawRecentProjectRow(const size_t index, const std::filesystem::path& path, const float row_width) {
@@ -767,7 +810,7 @@ class LauncherLayer final : public ILayer {
     }
 
     std::string error;
-    if (!LaunchEditorProcess(project_path, error)) {
+    if (!LaunchEditorProcess(project_path, selected_launch_mode_, error)) {
       launch_error_ = error;
       return;
     }
@@ -807,6 +850,10 @@ class LauncherLayer final : public ILayer {
 
   void AppendRecentProjectCountTestLog() const {
     AppendTestLog("recent-count:" + std::to_string(recent_project_paths_.size()));
+  }
+
+  void AppendLaunchModeTestLog() const {
+    AppendTestLog("launch-mode:" + std::string(GetApplicationModeName(selected_launch_mode_)));
   }
 
   void AddRecentProject(const std::filesystem::path& path) {

--- a/EvoEngine_App/src/EvoEngineLauncher.cpp
+++ b/EvoEngine_App/src/EvoEngineLauncher.cpp
@@ -144,6 +144,11 @@ constexpr float kTitleBarButtonSize = 14.0f;
 constexpr ImU32 kTitleBarColor = IM_COL32(21, 21, 21, 255);
 constexpr ImU32 kTitleBarText = IM_COL32(192, 192, 192, 255);
 constexpr ImU32 kTitleBarTextDarker = IM_COL32(128, 128, 128, 255);
+constexpr std::array<ApplicationMode, 2> kLauncherApplicationModes = {ApplicationMode::Editor, ApplicationMode::Player};
+
+ApplicationMode NormalizeLauncherApplicationMode(const ApplicationMode mode) {
+  return mode == ApplicationMode::Player ? ApplicationMode::Player : ApplicationMode::Editor;
+}
 
 ImU32 MultiplyColor(const ImU32 color, const float multiplier) {
   ImVec4 value = ImGui::ColorConvertU32ToFloat4(color);
@@ -315,7 +320,7 @@ class LauncherLayer final : public ILayer {
     AppendRecentProjectCountTestLog();
     AppendPackageAvailabilityTestLog();
     if (const char* launch_mode = std::getenv("EVOENGINE_LAUNCHER_TEST_APPLICATION_MODE")) {
-      selected_launch_mode_ = ParseApplicationModeName(launch_mode);
+      selected_launch_mode_ = NormalizeLauncherApplicationMode(ParseApplicationModeName(launch_mode));
     }
     AppendLaunchModeTestLog();
     AppendTestLog("mode:hub");
@@ -581,10 +586,11 @@ class LauncherLayer final : public ILayer {
   }
 
   void DrawLaunchModeSelector(const float width) {
+    selected_launch_mode_ = NormalizeLauncherApplicationMode(selected_launch_mode_);
     ImGui::TextUnformatted("Start Mode");
     ImGui::SetNextItemWidth(width);
     if (ImGui::BeginCombo("##StartMode", GetApplicationModeName(selected_launch_mode_))) {
-      for (const auto mode : {ApplicationMode::Editor, ApplicationMode::Player, ApplicationMode::Headless}) {
+      for (const auto mode : kLauncherApplicationModes) {
         const bool selected = selected_launch_mode_ == mode;
         if (ImGui::Selectable(GetApplicationModeName(mode), selected)) {
           selected_launch_mode_ = mode;
@@ -605,7 +611,6 @@ class LauncherLayer final : public ILayer {
         ImGui::TextColored(ColorTextMuted(), "Run the project scene without editor UI.");
         break;
       case ApplicationMode::Headless:
-        ImGui::TextColored(ColorTextMuted(), "Run without a window for automation/service use.");
         break;
     }
   }

--- a/EvoEngine_App/src/LSystemApp.cpp
+++ b/EvoEngine_App/src/LSystemApp.cpp
@@ -8,16 +8,12 @@
 #include <array>
 #include <filesystem>
 
+#include "AppBootstrap.hpp"
 #include "ClassRegistry.hpp"
 #include "PathUtils.hpp"
 #include "Times.hpp"
 
 #include "ProjectManager.hpp"
-
-#include "EditorLayer.hpp"
-#include "ImGuiLayer.hpp"
-#include "RenderLayer.hpp"
-#include "WindowLayer.hpp"
 
 using namespace evo_engine;
 
@@ -49,17 +45,16 @@ std::filesystem::path ResolveDefaultLSystemProjectPath(const std::filesystem::pa
 
 }  // namespace
 
-int main() {
+int main(const int argc, char** argv) {
   Application application;
+  const auto application_mode = ParseApplicationModeArguments(argc, argv);
   const auto resource_folder_path = FindResourceFolder();
   const auto lsystem_project_path = ResolveDefaultLSystemProjectPath(resource_folder_path);
 
-  ApplicationContext::Get().PushLayer<RenderLayer>("Render Layer");
-  ApplicationContext::Get().PushLayer<WindowLayer>("Window Layer");
-  ApplicationContext::Get().PushLayer<ImGuiLayer>("ImGui Layer");
-  ApplicationContext::Get().PushLayer<EditorLayer>("Editor Layer");
+  PushStandardApplicationLayers(application_mode);
 
   ApplicationInitializationSettings application_configs;
+  application_configs.application_mode = application_mode;
   application_configs.application_name = "LSystem";
   application_configs.project_path = lsystem_project_path;
   application_configs.enable_runtime_packages = true;
@@ -67,6 +62,7 @@ int main() {
   // Keep LSystem first while also loading DigitalAgriculture so copied
   // default-scene components deserialize with maximal compatibility.
   application_configs.startup_runtime_packages = {"LSystem", "DigitalAgriculture"};
+  ApplyApplicationModeDefaults(application_configs);
   ApplicationContext::Get().Initialize(application_configs);
 
   const auto editor_layer = ApplicationContext::Get().GetLayer<EditorLayer>();

--- a/EvoEngine_SDK/include/Application.hpp
+++ b/EvoEngine_SDK/include/Application.hpp
@@ -87,6 +87,7 @@ class Application final {
   void PreUpdateInternal();  /**< Perform internal pre-update tasks. */
   void UpdateInternal();     /**< Perform internal update tasks. */
   void LateUpdateInternal(); /**< Perform internal late-update tasks. */
+  void TryStartPendingPlayerAutoplay();
   void ExecuteEndOfLoopActions();
 
   std::vector<std::shared_ptr<ILayer>> layers_; /**< List of all layers added to the application. */
@@ -102,6 +103,7 @@ class Application final {
       post_attach_scene_functions_; /**< Functions called after a scene is attached. */
 
   ExecutionOrder execution_order = ExecutionOrder::NotPlaying; /**< Current execution status of the application. */
+  bool pending_player_autoplay_ = false; /**< Whether player mode should enter play once a start scene is attached. */
 
  public:
   [[nodiscard]] Serialization& GetSerialization();

--- a/EvoEngine_SDK/include/ApplicationInitializationSettings.hpp
+++ b/EvoEngine_SDK/include/ApplicationInitializationSettings.hpp
@@ -1,6 +1,12 @@
 #pragma once
 namespace evo_engine {
 
+enum class ApplicationMode {
+  Editor,  /**< Full editor/tooling mode. */
+  Player,  /**< Runtime player mode without editor UI. */
+  Headless /**< Non-windowed runtime mode reserved for tools and automation. */
+};
+
 /**
  * @brief Utility class for graphics settings.
  */
@@ -41,16 +47,17 @@ class GraphicsInitializationSettings {
  * @brief Structure for storing information about the application.
  */
 struct ApplicationInitializationSettings {
-  std::filesystem::path project_path;            /**< The path to the application's project. */
-  std::string application_name = "Evo Engine";   /**< The name of the application. */
-  std::vector<std::filesystem::path> icon_paths; /**< Paths to application icons. */
-  glm::ivec2 default_window_size = {1920, 1080}; /**< The default size of the application window. */
-  bool allow_empty_project = false;              /**< Whether initialization may proceed without a project path. */
-  bool enable_docking = true;                    /**< Whether to enable docking in the application. */
-  bool enable_viewport = true;                   /**< Whether to enable the viewport feature. */
-  bool full_screen = false;                      /**< Whether the application starts in full-screen mode. */
-  bool use_custom_title_bar = false;             /**< Whether supported platforms should use app-rendered chrome. */
-  bool hide_console_window = true; /**< Whether to hide an owned OS console window on supported platforms. */
+  ApplicationMode application_mode = ApplicationMode::Editor; /**< The runtime mode for layer setup and startup. */
+  std::filesystem::path project_path;                         /**< The path to the application's project. */
+  std::string application_name = "Evo Engine";                /**< The name of the application. */
+  std::vector<std::filesystem::path> icon_paths;              /**< Paths to application icons. */
+  glm::ivec2 default_window_size = {1920, 1080};              /**< The default size of the application window. */
+  bool allow_empty_project = false;  /**< Whether initialization may proceed without a project path. */
+  bool enable_docking = true;        /**< Whether to enable docking in the application. */
+  bool enable_viewport = true;       /**< Whether to enable the viewport feature. */
+  bool full_screen = false;          /**< Whether the application starts in full-screen mode. */
+  bool use_custom_title_bar = false; /**< Whether supported platforms should use app-rendered chrome. */
+  bool hide_console_window = true;   /**< Whether to hide an owned OS console window on supported platforms. */
   bool redirect_standard_streams_to_console =
       true;                             /**< Whether C++ stdout/stderr should be mirrored to Evo's console. */
   bool load_default_resources = true;   /**< Whether to load built-in default rendering resources. */

--- a/EvoEngine_SDK/include/Core/Profiler.hpp
+++ b/EvoEngine_SDK/include/Core/Profiler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -23,9 +24,43 @@ struct ProfilerFrameSnapshot {
   std::vector<ProfilerScopeEvent> events;
 };
 
+struct ProfilerAggregateTotal {
+  std::string name;
+  std::string category;
+  uint32_t count = 0;
+  double total_ms = 0.0;
+  double average_ms = 0.0;
+  double max_ms = 0.0;
+};
+
+struct ProfilerThreadLane {
+  uint64_t thread_id = 0;
+  std::string thread_name;
+  double total_ms = 0.0;
+  std::vector<ProfilerScopeEvent> events;
+};
+
+struct ProfilerFrameStats {
+  uint64_t frame_index = 0;
+  double duration_ms = 0.0;
+  uint32_t event_count = 0;
+  double total_event_ms = 0.0;
+  double max_event_ms = 0.0;
+  std::vector<ProfilerThreadLane> thread_lanes;
+  std::vector<ProfilerAggregateTotal> category_totals;
+  std::vector<ProfilerAggregateTotal> named_event_totals;
+};
+
 struct ProfilerScopeToken {
   bool active = false;
 };
+
+[[nodiscard]] ProfilerFrameStats BuildProfilerFrameStats(const ProfilerFrameSnapshot& snapshot);
+[[nodiscard]] std::vector<ProfilerFrameStats> BuildProfilerFrameStatsHistory(
+    const std::vector<ProfilerFrameSnapshot>& snapshots);
+[[nodiscard]] bool ExportProfilerChromeTrace(const std::filesystem::path& path,
+                                             const std::vector<ProfilerFrameSnapshot>& snapshots,
+                                             std::string* error = nullptr);
 
 class Profiler final {
  public:
@@ -34,6 +69,7 @@ class Profiler final {
   void SetEnabled(bool enabled);
   [[nodiscard]] bool IsEnabled() const;
   void Reset();
+  void ClearFrameHistory();
   void SetMaxFrameHistory(size_t max_frame_history);
 
   void RegisterThread(const std::string& name);
@@ -44,6 +80,9 @@ class Profiler final {
 
   [[nodiscard]] ProfilerFrameSnapshot GetLatestFrameSnapshot() const;
   [[nodiscard]] std::vector<ProfilerFrameSnapshot> GetFrameHistorySnapshot() const;
+  [[nodiscard]] ProfilerFrameStats GetLatestFrameStatsSnapshot() const;
+  [[nodiscard]] std::vector<ProfilerFrameStats> GetFrameStatsHistorySnapshot() const;
+  [[nodiscard]] bool ExportChromeTrace(const std::filesystem::path& path, std::string* error = nullptr) const;
 };
 
 class ProfilerScope final {

--- a/EvoEngine_SDK/include/Core/Profiler.hpp
+++ b/EvoEngine_SDK/include/Core/Profiler.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace evo_engine {
+
+struct ProfilerScopeEvent {
+  uint64_t frame_index = 0;
+  uint64_t thread_id = 0;
+  std::string thread_name;
+  std::string name;
+  std::string category;
+  uint32_t depth = 0;
+  double start_ms = 0.0;
+  double duration_ms = 0.0;
+};
+
+struct ProfilerFrameSnapshot {
+  uint64_t frame_index = 0;
+  double duration_ms = 0.0;
+  std::vector<ProfilerScopeEvent> events;
+};
+
+struct ProfilerScopeToken {
+  bool active = false;
+};
+
+class Profiler final {
+ public:
+  static Profiler& GetInstance();
+
+  void SetEnabled(bool enabled);
+  [[nodiscard]] bool IsEnabled() const;
+  void Reset();
+  void SetMaxFrameHistory(size_t max_frame_history);
+
+  void RegisterThread(const std::string& name);
+  uint64_t BeginFrame();
+  void EndFrame();
+  [[nodiscard]] ProfilerScopeToken BeginScope(const std::string& name, const std::string& category = "CPU");
+  void EndScope(ProfilerScopeToken& token);
+
+  [[nodiscard]] ProfilerFrameSnapshot GetLatestFrameSnapshot() const;
+  [[nodiscard]] std::vector<ProfilerFrameSnapshot> GetFrameHistorySnapshot() const;
+};
+
+class ProfilerScope final {
+  ProfilerScopeToken token_;
+
+ public:
+  explicit ProfilerScope(const std::string& name, const std::string& category = "CPU");
+  ~ProfilerScope();
+  ProfilerScope(const ProfilerScope&) = delete;
+  ProfilerScope& operator=(const ProfilerScope&) = delete;
+};
+
+class ProfilerFrameScope final {
+ public:
+  ProfilerFrameScope();
+  ~ProfilerFrameScope();
+  ProfilerFrameScope(const ProfilerFrameScope&) = delete;
+  ProfilerFrameScope& operator=(const ProfilerFrameScope&) = delete;
+};
+
+}  // namespace evo_engine

--- a/EvoEngine_SDK/include/Layers/EditorLayer.hpp
+++ b/EvoEngine_SDK/include/Layers/EditorLayer.hpp
@@ -10,6 +10,7 @@
 #include "Material.hpp"
 #include "Mesh.hpp"
 #include "PrivateComponentRef.hpp"
+#include "Profiler.hpp"
 #include "ProjectManager.hpp"
 #include "Scene.hpp"
 #include "Serialization.hpp"
@@ -53,6 +54,7 @@ struct EditorPanelVisibilitySettings {
   std::optional<bool> console;
   std::optional<bool> project;
   std::optional<bool> resources;
+  std::optional<bool> profiler;
   std::optional<bool> runtime_package_manager;
 };
 
@@ -320,6 +322,7 @@ class EditorLayer : public ILayer {
   bool show_entity_explorer_window = true;  /**< Indicates whether the entity explorer window is visible. */
   bool show_entity_inspector_window = true; /**< Indicates whether the entity inspector window is visible. */
   bool show_package_manager_window = false; /**< Indicates whether the runtime package manager window is visible. */
+  bool show_profiler_window = false;        /**< Indicates whether the profiler window is visible. */
   bool main_camera_focus_override = false;  /**< Indicates if the main camera focus has been overridden. */
   bool scene_camera_focus_override = false; /**< Indicates if the scene camera focus has been overridden. */
 
@@ -905,6 +908,7 @@ class EditorLayer : public ILayer {
   void DrawConsoleWindow();
   void DrawAssetInspectorWindows();
   void DrawRuntimePackageManagerWindow();
+  void DrawProfilerWindow();
   void HandleSceneDeleteShortcut(const std::shared_ptr<Scene>& scene);
   void DrawSceneCameraDebugWindow(const std::shared_ptr<Scene>& scene);
   void DrawLayerInspectionWindows(const std::shared_ptr<Scene>& scene,
@@ -934,6 +938,14 @@ class EditorLayer : public ILayer {
 
   Handle scene_camera_handle_ = 0;                          /**< Handle to the scene camera. */
   std::unordered_map<Handle, EditorCamera> editor_cameras_; /**< Map of handles to editor cameras. */
+
+  bool profiler_panel_paused_ = false;
+  bool profiler_pause_on_next_frame_ = false;
+  int profiler_history_length_ = 240;
+  int profiler_selected_frame_index_ = -1;
+  uint64_t profiler_cached_latest_frame_index_ = 0;
+  std::vector<ProfilerFrameStats> profiler_panel_frames_;
+  std::string profiler_export_status_;
 
   std::vector<GizmoMeshTask> gizmo_mesh_tasks_;                    /**< List of tasks for gizmo meshes. */
   std::vector<GizmoInstancedMeshTask> gizmo_instanced_mesh_tasks_; /**< List of tasks for instanced gizmo meshes. */

--- a/EvoEngine_SDK/src/Application.cpp
+++ b/EvoEngine_SDK/src/Application.cpp
@@ -1343,6 +1343,7 @@ void Application::PreUpdateInternal() {
   run_asset_tasks();
   TryStartPendingPlayerAutoplay();
   if (this->active_scene_) {
+    const ProfilerScope scene_scope("Application::ScenePreUpdate", "Scene");
     TransformGraph::CalculateTransformGraphs(this->active_scene_);
     for (const auto& i : this->external_pre_update_functions_)
       i();
@@ -1351,11 +1352,14 @@ void Application::PreUpdateInternal() {
     }
   }
 
-  for (size_t layer_index = 0; layer_index < this->layers_.size();) {
-    const auto layer = this->layers_[layer_index];
-    layer->PreUpdate();
-    if (layer_index < this->layers_.size() && this->layers_[layer_index] == layer) {
-      ++layer_index;
+  {
+    const ProfilerScope layers_scope("Application::LayerPreUpdate", "Layer");
+    for (size_t layer_index = 0; layer_index < this->layers_.size();) {
+      const auto layer = this->layers_[layer_index];
+      layer->PreUpdate();
+      if (layer_index < this->layers_.size() && this->layers_[layer_index] == layer) {
+        ++layer_index;
+      }
     }
   }
   if (times.steps_ == 0) {
@@ -1403,22 +1407,27 @@ void Application::UpdateInternal() {
 
   this->execution_order = ExecutionOrder::Update;
   if (this->active_scene_) {
+    const ProfilerScope scene_scope("Application::SceneUpdate", "Scene");
     if (this->execution_status_ == ExecutionStatus::Playing || this->execution_status_ == ExecutionStatus::Step) {
       this->active_scene_->Update();
     }
   }
 
-  for (size_t layer_index = 0; layer_index < this->layers_.size();) {
-    const auto layer = this->layers_[layer_index];
-    layer->Update();
-    if (layer_index < this->layers_.size() && this->layers_[layer_index] == layer) {
-      ++layer_index;
+  {
+    const ProfilerScope layers_scope("Application::LayerUpdate", "Layer");
+    for (size_t layer_index = 0; layer_index < this->layers_.size();) {
+      const auto layer = this->layers_[layer_index];
+      layer->Update();
+      if (layer_index < this->layers_.size() && this->layers_[layer_index] == layer) {
+        ++layer_index;
+      }
     }
   }
   for (const auto& i : this->external_update_functions_)
     i();
 
   if (const auto render_layer = GetLayer<RenderLayer>()) {
+    const ProfilerScope render_scope("Application::PrepareRendering", "Render");
     render_layer->PrepareForRendering();
     render_layer->ClearAllEditorCameras();
     render_layer->ClearAllCameras();
@@ -1452,16 +1461,19 @@ void Application::LateUpdateInternal() {
     this->execution_order = ExecutionOrder::LateUpdate;
 
     if (this->execution_status_ == ExecutionStatus::Playing || this->execution_status_ == ExecutionStatus::Step) {
+      const ProfilerScope scene_scope("Application::SceneLateUpdate", "Scene");
       this->active_scene_->LateUpdate();
     }
 
     if (render_layer) {
+      const ProfilerScope render_scope("Application::RenderSubmission", "Render");
       render_layer->RenderAll();
       render_layer->RenderGizmos();
     }
   }
 
   if (window_layer) {
+    const ProfilerScope window_scope("Application::WindowRender", "Render");
     window_layer->Render();
   }
   if (render_layer) {
@@ -1768,6 +1780,7 @@ bool Application::RemoveLayersOwnedByPackage(const std::string& package_name) {
 
 void Application::Attach(const std::shared_ptr<Scene>& scene) {
   ApplicationContextScope application_scope(*this);
+  const ProfilerScope profiler_scope("Application::AttachScene", "Scene Sync");
   if (this->execution_status_ == ExecutionStatus::Playing) {
     EVOENGINE_ERROR("Stop Application to attach scene")
   }

--- a/EvoEngine_SDK/src/Application.cpp
+++ b/EvoEngine_SDK/src/Application.cpp
@@ -30,6 +30,7 @@
 #include "Prefab.hpp"
 #include "PrivateComponentRef.hpp"
 #include "ProceduralNoise.hpp"
+#include "Profiler.hpp"
 #include "ProjectManager.hpp"
 #include "ReflectionProbe.hpp"
 #include "RenderLayer.hpp"
@@ -1232,6 +1233,7 @@ Application::Application()
       times_(std::make_unique<Times>()),
       transform_graph_(std::make_unique<TransformGraph>()) {
   ApplicationContext::Set(this);
+  Profiler::GetInstance().RegisterThread("MainThread");
 }
 
 Application::~Application() {
@@ -1309,6 +1311,7 @@ TransformGraph& Application::GetTransformGraph() {
 
 void Application::PreUpdateInternal() {
   ApplicationContextScope application_scope(*this);
+  const ProfilerScope profile_scope("Application::PreUpdate", "Frame");
   auto& times = GetTimes();
   const auto now = std::chrono::system_clock::now();
   const std::chrono::duration<double> delta_time = now - times.last_update_time_;
@@ -1338,6 +1341,7 @@ void Application::PreUpdateInternal() {
   run_asset_tasks();
   ProjectManager::PreUpdate();
   run_asset_tasks();
+  TryStartPendingPlayerAutoplay();
   if (this->active_scene_) {
     TransformGraph::CalculateTransformGraphs(this->active_scene_);
     for (const auto& i : this->external_pre_update_functions_)
@@ -1389,6 +1393,7 @@ void Application::PreUpdateInternal() {
 
 void Application::UpdateInternal() {
   ApplicationContextScope application_scope(*this);
+  const ProfilerScope profile_scope("Application::Update", "Frame");
   if (this->execution_status_ == ExecutionStatus::Uninitialized) {
     EVOENGINE_ERROR("Application uninitialized!")
     return;
@@ -1422,6 +1427,7 @@ void Application::UpdateInternal() {
 
 void Application::LateUpdateInternal() {
   ApplicationContextScope application_scope(*this);
+  const ProfilerScope profile_scope("Application::LateUpdate", "Frame");
   if (this->execution_status_ == ExecutionStatus::Uninitialized) {
     EVOENGINE_ERROR("Application uninitialized!")
     return;
@@ -1642,8 +1648,10 @@ void Application::Start(const bool autoplay) {
   auto& times = GetTimes();
   times.start_time_ = std::chrono::system_clock::now();
   times.steps_ = times.frames_ = 0;
-  if (const auto editor_layer = GetLayer<EditorLayer>(); !editor_layer && autoplay)
-    Play();
+  const bool runtime_autoplay_mode = initialization_settings.application_mode == ApplicationMode::Player ||
+                                     initialization_settings.application_mode == ApplicationMode::Headless;
+  pending_player_autoplay_ = autoplay && runtime_autoplay_mode && !GetLayer<EditorLayer>();
+  TryStartPendingPlayerAutoplay();
 }
 
 void Application::Run() {
@@ -1654,6 +1662,8 @@ void Application::Run() {
 bool Application::Loop() {
   const ApplicationContextScope application_scope(*this);
   if (this->execution_status_ != ExecutionStatus::OnDestroy) {
+    const ProfilerFrameScope profiler_frame_scope;
+    const ProfilerScope profiler_scope("Application::Loop", "Frame");
     PreUpdateInternal();
     UpdateInternal();
     LateUpdateInternal();
@@ -1686,6 +1696,7 @@ void Application::ExecuteEndOfLoopActions() {
 void Application::Terminate() {
   ApplicationContextScope application_scope(*this);
   this->execution_status_ = ExecutionStatus::OnDestroy;
+  pending_player_autoplay_ = false;
   const bool has_render_layer = GetLayer<RenderLayer>() != nullptr;
   for (auto i = this->layers_.rbegin(); i != this->layers_.rend(); ++i) {
     (*i)->OnDestroy();
@@ -1768,6 +1779,16 @@ void Application::Attach(const std::shared_ptr<Scene>& scene) {
   for (const auto& layer : this->layers_) {
     layer->scene_ = scene;
   }
+  TryStartPendingPlayerAutoplay();
+}
+
+void Application::TryStartPendingPlayerAutoplay() {
+  if (!pending_player_autoplay_ || !active_scene_ || execution_status_ != ExecutionStatus::NotPlaying ||
+      !ProjectManager::IsProjectIdle()) {
+    return;
+  }
+  pending_player_autoplay_ = false;
+  Play();
 }
 
 void Application::Play() {

--- a/EvoEngine_SDK/src/AssetManager.cpp
+++ b/EvoEngine_SDK/src/AssetManager.cpp
@@ -6,6 +6,7 @@
 #include "FileManager.hpp"
 #include "InspectorRegistry.hpp"
 #include "Jobs.hpp"
+#include "Profiler.hpp"
 #include "ProjectManager.hpp"
 #include "Resources.hpp"
 #include "Texture2D.hpp"
@@ -495,6 +496,7 @@ size_t AssetManager::ExecuteMainThreadAssetTasks(const size_t max_task_size) {
 
 size_t AssetManager::ExecuteMainThreadAssetTasksWithinBudget(const size_t max_task_size,
                                                              const std::chrono::milliseconds max_duration) {
+  const ProfilerScope profiler_scope("AssetManager::ExecuteMainThreadAssetTasks", "Asset Finalize");
   size_t executed_task_size = 0;
   const auto budget_start = std::chrono::steady_clock::now();
   while (max_task_size == 0 || executed_task_size < max_task_size) {
@@ -515,6 +517,8 @@ size_t AssetManager::ExecuteMainThreadAssetTasksWithinBudget(const size_t max_ta
     }
     if (task.action) {
       const auto task_start = std::chrono::steady_clock::now();
+      const ProfilerScope task_scope(task.label.empty() ? "AssetManager::MainThreadAssetTask" : task.label,
+                                     "Asset Finalize");
       task.action();
       const auto task_duration =
           std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - task_start);
@@ -528,6 +532,7 @@ size_t AssetManager::ExecuteMainThreadAssetTasksWithinBudget(const size_t max_ta
 }
 
 std::shared_ptr<IAsset> AssetManager::LoadAssetImpl(const Handle& asset_handle) {
+  const ProfilerScope profiler_scope("AssetManager::LoadAsset", "Asset Load");
   auto& asset_manager = GetInstance();
   {
     std::lock_guard lock(asset_manager.asset_registry_.asset_registry_mutex);
@@ -590,6 +595,7 @@ void AssetManager::StartAssetServiceLoadImpl(const Handle& asset_handle,
     const auto context_future = context_promise->get_future().share();
     ScheduleMainThreadAssetTaskImpl(
         [asset_handle, context_promise]() {
+          const ProfilerScope profiler_scope("AssetManager::CreateAssetObject", "Asset Finalize");
           try {
             auto& asset_manager = GetInstance();
             {
@@ -650,6 +656,7 @@ void AssetManager::StartAssetServiceLoadImpl(const Handle& asset_handle,
 
     if (context.staged) {
       UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::LoadingCpu, "Loading CPU payload.");
+      const ProfilerScope payload_scope("AssetManager::LoadStagedPayload", "Asset Load");
       auto payload = Serialization::LoadStagedAssetPayload(*context.asset, context.absolute_path);
       if (!payload) {
         throw std::runtime_error("Failed to build staged asset payload.");
@@ -657,6 +664,7 @@ void AssetManager::StartAssetServiceLoadImpl(const Handle& asset_handle,
       UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::WaitingForFinalize, "Waiting for asset finalization.");
       ScheduleMainThreadAssetTaskImpl(
           [asset_handle, context = std::move(context), promise, payload = std::move(payload)]() {
+            const ProfilerScope profiler_scope("AssetManager::FinalizeStagedAsset", "Asset Finalize");
             try {
               if (!Serialization::ApplyStagedAssetPayload(*context.asset, context.absolute_path, payload)) {
                 throw std::runtime_error("Failed to apply staged asset load payload.");
@@ -684,6 +692,7 @@ void AssetManager::StartAssetServiceLoadImpl(const Handle& asset_handle,
                 const auto gpu_ready_handle = Jobs::Run(
                     *pending_handles, gpu_ready_options,
                     [asset_handle, promise, publish_loaded_asset, pending_handles]() {
+                      const ProfilerScope profiler_scope("AssetManager::WaitForAssetGpuReady", "Asset Finalize");
                       try {
                         for (const auto& handle : *pending_handles) {
                           Jobs::Wait(handle);
@@ -724,6 +733,7 @@ void AssetManager::StartAssetServiceLoadImpl(const Handle& asset_handle,
     UpdateAssetLoadStateImpl(asset_handle, AssetLoadState::WaitingForFinalize, "Waiting for legacy asset load.");
     ScheduleMainThreadAssetTaskImpl(
         [asset_handle, context = std::move(context), promise]() {
+          const ProfilerScope profiler_scope("AssetManager::FinalizeLegacyAsset", "Asset Finalize");
           try {
             if (context.path_exists) {
               context.asset->Load();

--- a/EvoEngine_SDK/src/EditorLayer.cpp
+++ b/EvoEngine_SDK/src/EditorLayer.cpp
@@ -22,6 +22,7 @@
 #include "Serialization.hpp"
 #include "StrandsRenderer.hpp"
 #include "Times.hpp"
+#include "Utilities.hpp"
 #include "WindowLayer.hpp"
 
 #include "imgui_internal.h"
@@ -31,6 +32,7 @@
 #include <cctype>
 #include <chrono>
 #include <cstdio>
+#include <filesystem>
 #include <functional>
 #include <unordered_map>
 
@@ -93,6 +95,23 @@ bool CurrentTitleBarAccent(ImU32& accent) {
       return false;
   }
   return false;
+}
+
+ImU32 ProfilerCategoryColor(const std::string& category) {
+  const auto hash = std::hash<std::string>{}(category);
+  const float hue = static_cast<float>(hash % 360) / 360.0f;
+  float r = 0.0f;
+  float g = 0.0f;
+  float b = 0.0f;
+  ImGui::ColorConvertHSVtoRGB(hue, 0.55f, 0.90f, r, g, b);
+  return ImGui::GetColorU32(ImVec4(r, g, b, 0.85f));
+}
+
+std::filesystem::path DefaultProfilerTracePath() {
+  if (ProjectManager::HasProject()) {
+    return ProjectManager::GetProjectPath().parent_path() / "ProfilerTrace.json";
+  }
+  return std::filesystem::current_path() / "ProfilerTrace.json";
 }
 
 bool TextContainsCaseInsensitive(const std::string& text, const std::string& query) {
@@ -1171,6 +1190,9 @@ void EditorLayer::RegisterEditorPanels() {
                  [this](const std::shared_ptr<EditorLayer>&) {
                    DrawRuntimePackageManagerWindow();
                  });
+  register_panel("profiler", "Profiler", show_profiler_window, [this](const std::shared_ptr<EditorLayer>&) {
+    DrawProfilerWindow();
+  });
   register_panel("resources", "Resources", Resources::GetInstance().show_resources_,
                  [](const std::shared_ptr<EditorLayer>& editor_layer) {
                    Resources::Draw(editor_layer);
@@ -1490,11 +1512,17 @@ void EditorLayer::DrawConsoleWindow() {
     ImGui::SameLine();
     ImGui::Checkbox("Error", &enable_console_errors_);
     ImGui::SameLine();
+    std::vector<ConsoleMessage> console_messages;
     if (ImGui::Button("Clear all")) {
+      std::lock_guard lock(console_message_mutex_);
       console_messages_.clear();
     }
+    {
+      std::lock_guard lock(console_message_mutex_);
+      console_messages = console_messages_;
+    }
     int i = 0;
-    for (auto msg = console_messages_.rbegin(); msg != console_messages_.rend(); ++msg) {
+    for (auto msg = console_messages.rbegin(); msg != console_messages.rend(); ++msg) {
       if (i > 999)
         break;
       i++;
@@ -1963,6 +1991,234 @@ void EditorLayer::DrawRuntimePackageManagerWindow() {
   ImGui::End();
 }
 
+void EditorLayer::DrawProfilerWindow() {
+  if (!show_profiler_window) {
+    return;
+  }
+
+  auto& profiler = Profiler::GetInstance();
+  bool profiler_open = show_profiler_window;
+  if (!ImGui::Begin("Profiler", &profiler_open)) {
+    show_profiler_window = profiler_open;
+    ImGui::End();
+    return;
+  }
+  show_profiler_window = profiler_open;
+
+  bool capture_enabled = profiler.IsEnabled();
+  if (ImGui::Checkbox("Capture", &capture_enabled)) {
+    profiler.SetEnabled(capture_enabled);
+  }
+  ImGui::SameLine();
+  if (ImGui::Button(profiler_panel_paused_ ? "Resume" : "Pause")) {
+    profiler_panel_paused_ = !profiler_panel_paused_;
+  }
+  ImGui::SameLine();
+  ImGui::Checkbox("Pause on next frame", &profiler_pause_on_next_frame_);
+  ImGui::SameLine();
+  if (ImGui::Button("Clear")) {
+    profiler.ClearFrameHistory();
+    profiler_panel_frames_.clear();
+    profiler_selected_frame_index_ = -1;
+    profiler_cached_latest_frame_index_ = 0;
+  }
+
+  if (ImGui::SliderInt("History", &profiler_history_length_, 30, 2000)) {
+    profiler.SetMaxFrameHistory(static_cast<size_t>(profiler_history_length_));
+  }
+
+  if (!profiler_panel_paused_) {
+    auto frames = profiler.GetFrameStatsHistorySnapshot();
+    if (!frames.empty()) {
+      const auto latest_frame_index = frames.back().frame_index;
+      profiler_panel_frames_ = std::move(frames);
+      if (profiler_selected_frame_index_ < 0 ||
+          profiler_selected_frame_index_ >= static_cast<int>(profiler_panel_frames_.size())) {
+        profiler_selected_frame_index_ = static_cast<int>(profiler_panel_frames_.size()) - 1;
+      }
+      if (profiler_pause_on_next_frame_ && latest_frame_index != profiler_cached_latest_frame_index_) {
+        profiler_panel_paused_ = true;
+        profiler_pause_on_next_frame_ = false;
+        profiler_selected_frame_index_ = static_cast<int>(profiler_panel_frames_.size()) - 1;
+      }
+      profiler_cached_latest_frame_index_ = latest_frame_index;
+    }
+  }
+
+  if (profiler_panel_frames_.empty()) {
+    ImGui::TextUnformatted("No profiler frames captured.");
+    ImGui::End();
+    return;
+  }
+
+  const auto export_frames = profiler.GetFrameHistorySnapshot();
+  if (ImGui::Button("Quick Export Trace")) {
+    std::string error;
+    const auto export_path = DefaultProfilerTracePath();
+    if (ExportProfilerChromeTrace(export_path, export_frames, &error)) {
+      profiler_export_status_ = "Exported " + export_path.string();
+    } else {
+      profiler_export_status_ = "Export failed: " + error;
+    }
+  }
+  ImGui::SameLine();
+  FileUtils::SaveFile(
+      "Export Trace...", "Chrome Trace JSON", {".json"},
+      [export_frames, this](const std::filesystem::path& path) {
+        std::string error;
+        if (ExportProfilerChromeTrace(path, export_frames, &error)) {
+          profiler_export_status_ = "Exported " + path.string();
+        } else {
+          profiler_export_status_ = "Export failed: " + error;
+        }
+      },
+      false);
+  if (!profiler_export_status_.empty()) {
+    ImGui::TextWrapped("%s", profiler_export_status_.c_str());
+  }
+
+  std::vector<float> frame_times;
+  frame_times.reserve(profiler_panel_frames_.size());
+  float max_frame_time = 16.0f;
+  for (const auto& frame : profiler_panel_frames_) {
+    const float frame_time = static_cast<float>(frame.duration_ms);
+    frame_times.emplace_back(frame_time);
+    max_frame_time = std::max(max_frame_time, frame_time);
+  }
+  ImGui::PlotLines("Frame Time", frame_times.data(), static_cast<int>(frame_times.size()), 0, nullptr, 0.0f,
+                   max_frame_time, ImVec2(0.0f, 80.0f));
+
+  if (ImGui::BeginChild("ProfilerFrameList", ImVec2(0.0f, 84.0f), true)) {
+    for (int i = 0; i < static_cast<int>(profiler_panel_frames_.size()); ++i) {
+      const auto& frame = profiler_panel_frames_[i];
+      ImGui::PushID(i);
+      const bool selected = profiler_selected_frame_index_ == i;
+      if (ImGui::Selectable(("Frame " + std::to_string(frame.frame_index)).c_str(), selected, 0,
+                            ImVec2(120.0f, 0.0f))) {
+        profiler_selected_frame_index_ = i;
+        profiler_panel_paused_ = true;
+      }
+      ImGui::SameLine();
+      ImGui::Text("%.2f ms", frame.duration_ms);
+      if (i + 1 < static_cast<int>(profiler_panel_frames_.size())) {
+        ImGui::SameLine();
+      }
+      ImGui::PopID();
+    }
+  }
+  ImGui::EndChild();
+
+  profiler_selected_frame_index_ =
+      std::clamp(profiler_selected_frame_index_, 0, static_cast<int>(profiler_panel_frames_.size()) - 1);
+  const auto& selected_frame = profiler_panel_frames_[profiler_selected_frame_index_];
+  ImGui::Text("Frame %llu  %.2f ms  %u events  total scope %.2f ms",
+              static_cast<unsigned long long>(selected_frame.frame_index), selected_frame.duration_ms,
+              selected_frame.event_count, selected_frame.total_event_ms);
+
+  if (ImGui::BeginChild("ProfilerTimeline", ImVec2(0.0f, 220.0f), true, ImGuiWindowFlags_HorizontalScrollbar)) {
+    const float timeline_width = std::max(1.0f, ImGui::GetContentRegionAvail().x - 160.0f);
+    const float row_height = 24.0f;
+    const float scale = timeline_width / std::max(0.001f, static_cast<float>(selected_frame.duration_ms));
+    auto* draw_list = ImGui::GetWindowDrawList();
+    for (const auto& lane : selected_frame.thread_lanes) {
+      const auto row_origin = ImGui::GetCursorScreenPos();
+      ImGui::Text("%s", lane.thread_name.c_str());
+      const float timeline_x = row_origin.x + 150.0f;
+      const float timeline_y = row_origin.y;
+      draw_list->AddRectFilled(ImVec2(timeline_x, timeline_y), ImVec2(timeline_x + timeline_width, timeline_y + 18.0f),
+                               ImGui::GetColorU32(ImGuiCol_FrameBg), 3.0f);
+      for (const auto& event : lane.events) {
+        const float event_x = timeline_x + static_cast<float>(event.start_ms) * scale;
+        const float event_width = std::max(1.0f, static_cast<float>(event.duration_ms) * scale);
+        const float event_y = timeline_y + 2.0f + static_cast<float>(event.depth % 3) * 4.0f;
+        draw_list->AddRectFilled(ImVec2(event_x, event_y), ImVec2(event_x + event_width, event_y + 12.0f),
+                                 ProfilerCategoryColor(event.category), 2.0f);
+      }
+      ImGui::Dummy(ImVec2(timeline_width + 160.0f, row_height));
+    }
+  }
+  ImGui::EndChild();
+
+  if (ImGui::BeginTable("ProfilerTotals", 2, ImGuiTableFlags_Resizable | ImGuiTableFlags_BordersInnerV)) {
+    ImGui::TableNextColumn();
+    ImGui::TextUnformatted("Categories");
+    if (ImGui::BeginTable("ProfilerCategoryTotals", 4, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV)) {
+      ImGui::TableSetupColumn("Category");
+      ImGui::TableSetupColumn("Count");
+      ImGui::TableSetupColumn("Total");
+      ImGui::TableSetupColumn("Max");
+      ImGui::TableHeadersRow();
+      for (const auto& total : selected_frame.category_totals) {
+        ImGui::TableNextRow();
+        ImGui::TableNextColumn();
+        ImGui::TextUnformatted(total.category.c_str());
+        ImGui::TableNextColumn();
+        ImGui::Text("%u", total.count);
+        ImGui::TableNextColumn();
+        ImGui::Text("%.2f", total.total_ms);
+        ImGui::TableNextColumn();
+        ImGui::Text("%.2f", total.max_ms);
+      }
+      ImGui::EndTable();
+    }
+    ImGui::TableNextColumn();
+    ImGui::TextUnformatted("Events");
+    if (ImGui::BeginTable("ProfilerEventTotals", 4, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV)) {
+      ImGui::TableSetupColumn("Name");
+      ImGui::TableSetupColumn("Category");
+      ImGui::TableSetupColumn("Count");
+      ImGui::TableSetupColumn("Total");
+      ImGui::TableHeadersRow();
+      for (const auto& total : selected_frame.named_event_totals) {
+        ImGui::TableNextRow();
+        ImGui::TableNextColumn();
+        ImGui::TextUnformatted(total.name.c_str());
+        ImGui::TableNextColumn();
+        ImGui::TextUnformatted(total.category.c_str());
+        ImGui::TableNextColumn();
+        ImGui::Text("%u", total.count);
+        ImGui::TableNextColumn();
+        ImGui::Text("%.2f", total.total_ms);
+      }
+      ImGui::EndTable();
+    }
+    ImGui::EndTable();
+  }
+
+  if (ImGui::BeginTable(
+          "ProfilerEvents", 6,
+          ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders | ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY,
+          ImVec2(0.0f, 260.0f))) {
+    ImGui::TableSetupColumn("Thread");
+    ImGui::TableSetupColumn("Name");
+    ImGui::TableSetupColumn("Category");
+    ImGui::TableSetupColumn("Start");
+    ImGui::TableSetupColumn("Duration");
+    ImGui::TableSetupColumn("Depth");
+    ImGui::TableHeadersRow();
+    for (const auto& lane : selected_frame.thread_lanes) {
+      for (const auto& event : lane.events) {
+        ImGui::TableNextRow();
+        ImGui::TableNextColumn();
+        ImGui::TextUnformatted(lane.thread_name.c_str());
+        ImGui::TableNextColumn();
+        ImGui::TextUnformatted(event.name.c_str());
+        ImGui::TableNextColumn();
+        ImGui::TextUnformatted(event.category.c_str());
+        ImGui::TableNextColumn();
+        ImGui::Text("%.2f", event.start_ms);
+        ImGui::TableNextColumn();
+        ImGui::Text("%.2f", event.duration_ms);
+        ImGui::TableNextColumn();
+        ImGui::Text("%u", event.depth);
+      }
+    }
+    ImGui::EndTable();
+  }
+
+  ImGui::End();
+}
+
 void EditorLayer::PollRuntimePackageBuildJobs() {
   bool refresh_packages = false;
   for (auto& [package_name, job] : runtime_package_build_jobs_) {
@@ -2061,6 +2317,7 @@ void EditorLayer::DrawLayerSettingsWindow(const std::shared_ptr<EditorLayer>& ed
   ImGui::Checkbox("Entity Inspector", &show_entity_inspector_window);
   ImGui::Checkbox("Console", &show_console_window);
   ImGui::Checkbox("Runtime Packages", &show_package_manager_window);
+  ImGui::Checkbox("Profiler", &show_profiler_window);
 
   if (ImGui::TreeNode("Scene camera settings")) {
     ImGui::Checkbox("View Gizmos", &enable_view_gizmos);
@@ -2530,6 +2787,7 @@ void EditorLayer::DrawMainMenuItems(const bool title_bar_style) {
       ImGui::EndMenu();
     }
     ImGui::Separator();
+    panel_menu_item("Profiler", show_profiler_window);
     draw_layer_inspection_menu();
     end_menu();
   }
@@ -2642,6 +2900,7 @@ void EditorLayer::RequestEditorLayout(const EditorLayoutSettings& settings) {
   apply_visibility(settings.panels.console, show_console_window);
   apply_visibility(settings.panels.project, ProjectManager::GetInstance().show_project_window);
   apply_visibility(settings.panels.resources, Resources::GetInstance().show_resources_);
+  apply_visibility(settings.panels.profiler, show_profiler_window);
   apply_visibility(settings.panels.runtime_package_manager, show_package_manager_window);
 
   if (project_content_browser_panel_ && settings.project_browser) {

--- a/EvoEngine_SDK/src/Profiler.cpp
+++ b/EvoEngine_SDK/src/Profiler.cpp
@@ -1,0 +1,226 @@
+#include "Profiler.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+
+using namespace evo_engine;
+
+namespace {
+using ProfilerClock = std::chrono::steady_clock;
+
+struct ActiveProfilerScope {
+  std::string name;
+  std::string category;
+  ProfilerClock::time_point start_time;
+  ProfilerClock::time_point frame_start_time;
+  uint64_t frame_index = 0;
+  uint64_t thread_id = 0;
+  uint32_t depth = 0;
+};
+
+thread_local std::vector<ActiveProfilerScope> g_active_scopes;
+
+uint64_t CurrentThreadId() {
+  return static_cast<uint64_t>(std::hash<std::thread::id>{}(std::this_thread::get_id()));
+}
+
+double MillisecondsBetween(const ProfilerClock::time_point start_time, const ProfilerClock::time_point end_time) {
+  return std::chrono::duration<double, std::milli>(end_time - start_time).count();
+}
+
+std::string DefaultThreadName(const uint64_t thread_id) {
+  return "Thread " + std::to_string(thread_id);
+}
+
+class ProfilerState {
+ public:
+  std::atomic_bool enabled{true};
+  mutable std::mutex mutex;
+  uint64_t active_frame_index = 0;
+  bool frame_open = false;
+  ProfilerClock::time_point frame_start_time = ProfilerClock::now();
+  std::vector<ProfilerScopeEvent> completed_events;
+  std::deque<ProfilerFrameSnapshot> frame_history;
+  std::unordered_map<uint64_t, std::string> thread_names;
+  size_t max_frame_history = 240;
+  size_t max_completed_event_size = 65536;
+};
+
+ProfilerState& State() {
+  static ProfilerState state;
+  return state;
+}
+}  // namespace
+
+Profiler& Profiler::GetInstance() {
+  static Profiler profiler;
+  return profiler;
+}
+
+void Profiler::SetEnabled(const bool enabled) {
+  State().enabled = enabled;
+}
+
+bool Profiler::IsEnabled() const {
+  return State().enabled.load();
+}
+
+void Profiler::Reset() {
+  auto& state = State();
+  std::lock_guard lock(state.mutex);
+  state.active_frame_index = 0;
+  state.frame_open = false;
+  state.frame_start_time = ProfilerClock::now();
+  state.completed_events.clear();
+  state.frame_history.clear();
+  state.thread_names.clear();
+  g_active_scopes.clear();
+}
+
+void Profiler::SetMaxFrameHistory(const size_t max_frame_history) {
+  auto& state = State();
+  std::lock_guard lock(state.mutex);
+  state.max_frame_history = std::max<size_t>(1, max_frame_history);
+  while (state.frame_history.size() > state.max_frame_history) {
+    state.frame_history.pop_front();
+  }
+}
+
+void Profiler::RegisterThread(const std::string& name) {
+  auto& state = State();
+  std::lock_guard lock(state.mutex);
+  state.thread_names[CurrentThreadId()] = name;
+}
+
+uint64_t Profiler::BeginFrame() {
+  if (!IsEnabled()) {
+    return 0;
+  }
+  auto& state = State();
+  std::lock_guard lock(state.mutex);
+  state.frame_open = true;
+  state.frame_start_time = ProfilerClock::now();
+  return ++state.active_frame_index;
+}
+
+void Profiler::EndFrame() {
+  if (!IsEnabled()) {
+    return;
+  }
+  auto& state = State();
+  std::lock_guard lock(state.mutex);
+  if (!state.frame_open) {
+    return;
+  }
+
+  ProfilerFrameSnapshot frame;
+  frame.frame_index = state.active_frame_index;
+  frame.duration_ms = MillisecondsBetween(state.frame_start_time, ProfilerClock::now());
+  auto new_end = std::remove_if(state.completed_events.begin(), state.completed_events.end(),
+                                [&](const ProfilerScopeEvent& event) {
+                                  if (event.frame_index <= frame.frame_index) {
+                                    frame.events.emplace_back(event);
+                                    return true;
+                                  }
+                                  return false;
+                                });
+  state.completed_events.erase(new_end, state.completed_events.end());
+  state.frame_history.emplace_back(std::move(frame));
+  while (state.frame_history.size() > state.max_frame_history) {
+    state.frame_history.pop_front();
+  }
+  state.frame_open = false;
+}
+
+ProfilerScopeToken Profiler::BeginScope(const std::string& name, const std::string& category) {
+  if (!IsEnabled()) {
+    return {};
+  }
+  auto& state = State();
+  const auto now = ProfilerClock::now();
+  ActiveProfilerScope scope;
+  scope.name = name;
+  scope.category = category;
+  scope.start_time = now;
+  scope.thread_id = CurrentThreadId();
+  scope.depth = static_cast<uint32_t>(g_active_scopes.size());
+  {
+    std::lock_guard lock(state.mutex);
+    scope.frame_index = state.active_frame_index;
+    scope.frame_start_time = state.frame_open ? state.frame_start_time : now;
+  }
+  g_active_scopes.emplace_back(std::move(scope));
+  return {true};
+}
+
+void Profiler::EndScope(ProfilerScopeToken& token) {
+  if (!token.active) {
+    return;
+  }
+  token.active = false;
+  if (g_active_scopes.empty()) {
+    return;
+  }
+
+  auto scope = std::move(g_active_scopes.back());
+  g_active_scopes.pop_back();
+  ProfilerScopeEvent event;
+  event.frame_index = scope.frame_index;
+  event.thread_id = scope.thread_id;
+  event.name = std::move(scope.name);
+  event.category = std::move(scope.category);
+  event.depth = scope.depth;
+  const auto end_time = ProfilerClock::now();
+  event.start_ms = MillisecondsBetween(scope.frame_start_time, scope.start_time);
+  event.duration_ms = MillisecondsBetween(scope.start_time, end_time);
+
+  auto& state = State();
+  std::lock_guard lock(state.mutex);
+  if (const auto search = state.thread_names.find(event.thread_id); search != state.thread_names.end()) {
+    event.thread_name = search->second;
+  } else {
+    event.thread_name = DefaultThreadName(event.thread_id);
+  }
+  state.completed_events.emplace_back(std::move(event));
+  if (state.completed_events.size() > state.max_completed_event_size) {
+    state.completed_events.erase(state.completed_events.begin());
+  }
+}
+
+ProfilerFrameSnapshot Profiler::GetLatestFrameSnapshot() const {
+  const auto& state = State();
+  std::lock_guard lock(state.mutex);
+  if (state.frame_history.empty()) {
+    return {};
+  }
+  return state.frame_history.back();
+}
+
+std::vector<ProfilerFrameSnapshot> Profiler::GetFrameHistorySnapshot() const {
+  const auto& state = State();
+  std::lock_guard lock(state.mutex);
+  return {state.frame_history.begin(), state.frame_history.end()};
+}
+
+ProfilerScope::ProfilerScope(const std::string& name, const std::string& category)
+    : token_(Profiler::GetInstance().BeginScope(name, category)) {
+}
+
+ProfilerScope::~ProfilerScope() {
+  Profiler::GetInstance().EndScope(token_);
+}
+
+ProfilerFrameScope::ProfilerFrameScope() {
+  Profiler::GetInstance().BeginFrame();
+}
+
+ProfilerFrameScope::~ProfilerFrameScope() {
+  Profiler::GetInstance().EndFrame();
+}

--- a/EvoEngine_SDK/src/Profiler.cpp
+++ b/EvoEngine_SDK/src/Profiler.cpp
@@ -4,8 +4,11 @@
 #include <atomic>
 #include <chrono>
 #include <deque>
+#include <fstream>
 #include <functional>
+#include <iomanip>
 #include <mutex>
+#include <sstream>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -39,6 +42,77 @@ std::string DefaultThreadName(const uint64_t thread_id) {
   return "Thread " + std::to_string(thread_id);
 }
 
+std::string JsonEscape(const std::string& value) {
+  std::string escaped;
+  escaped.reserve(value.size());
+  for (const char c : value) {
+    switch (c) {
+      case '"':
+        escaped += "\\\"";
+        break;
+      case '\\':
+        escaped += "\\\\";
+        break;
+      case '\b':
+        escaped += "\\b";
+        break;
+      case '\f':
+        escaped += "\\f";
+        break;
+      case '\n':
+        escaped += "\\n";
+        break;
+      case '\r':
+        escaped += "\\r";
+        break;
+      case '\t':
+        escaped += "\\t";
+        break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          std::ostringstream stream;
+          stream << "\\u" << std::hex << std::uppercase << std::setw(4) << std::setfill('0')
+                 << static_cast<int>(static_cast<unsigned char>(c));
+          escaped += stream.str();
+        } else {
+          escaped += c;
+        }
+        break;
+    }
+  }
+  return escaped;
+}
+
+void AccumulateTotal(std::vector<ProfilerAggregateTotal>& totals, std::unordered_map<std::string, size_t>& indices,
+                     const std::string& key, const std::string& name, const std::string& category,
+                     const double duration_ms) {
+  auto search = indices.find(key);
+  if (search == indices.end()) {
+    search = indices.emplace(key, totals.size()).first;
+    auto& total = totals.emplace_back();
+    total.name = name;
+    total.category = category;
+  }
+
+  auto& total = totals[search->second];
+  ++total.count;
+  total.total_ms += duration_ms;
+  total.average_ms = total.total_ms / total.count;
+  total.max_ms = std::max(total.max_ms, duration_ms);
+}
+
+void SortTotals(std::vector<ProfilerAggregateTotal>& totals) {
+  std::sort(totals.begin(), totals.end(), [](const ProfilerAggregateTotal& a, const ProfilerAggregateTotal& b) {
+    if (a.total_ms != b.total_ms) {
+      return a.total_ms > b.total_ms;
+    }
+    if (a.category != b.category) {
+      return a.category < b.category;
+    }
+    return a.name < b.name;
+  });
+}
+
 class ProfilerState {
  public:
   std::atomic_bool enabled{true};
@@ -58,6 +132,123 @@ ProfilerState& State() {
   return state;
 }
 }  // namespace
+
+ProfilerFrameStats evo_engine::BuildProfilerFrameStats(const ProfilerFrameSnapshot& snapshot) {
+  ProfilerFrameStats stats;
+  stats.frame_index = snapshot.frame_index;
+  stats.duration_ms = snapshot.duration_ms;
+  stats.event_count = static_cast<uint32_t>(snapshot.events.size());
+
+  std::unordered_map<uint64_t, size_t> lane_indices;
+  std::unordered_map<std::string, size_t> category_indices;
+  std::unordered_map<std::string, size_t> event_indices;
+  for (const auto& event : snapshot.events) {
+    stats.total_event_ms += event.duration_ms;
+    stats.max_event_ms = std::max(stats.max_event_ms, event.duration_ms);
+
+    auto lane_search = lane_indices.find(event.thread_id);
+    if (lane_search == lane_indices.end()) {
+      lane_search = lane_indices.emplace(event.thread_id, stats.thread_lanes.size()).first;
+      auto& lane = stats.thread_lanes.emplace_back();
+      lane.thread_id = event.thread_id;
+      lane.thread_name = event.thread_name;
+    }
+    auto& lane = stats.thread_lanes[lane_search->second];
+    lane.total_ms += event.duration_ms;
+    lane.events.emplace_back(event);
+
+    AccumulateTotal(stats.category_totals, category_indices, event.category, event.category, event.category,
+                    event.duration_ms);
+    AccumulateTotal(stats.named_event_totals, event_indices, event.category + "\n" + event.name, event.name,
+                    event.category, event.duration_ms);
+  }
+
+  for (auto& lane : stats.thread_lanes) {
+    std::sort(lane.events.begin(), lane.events.end(), [](const ProfilerScopeEvent& a, const ProfilerScopeEvent& b) {
+      if (a.start_ms != b.start_ms) {
+        return a.start_ms < b.start_ms;
+      }
+      return a.depth < b.depth;
+    });
+  }
+  std::sort(stats.thread_lanes.begin(), stats.thread_lanes.end(),
+            [](const ProfilerThreadLane& a, const ProfilerThreadLane& b) {
+              if (a.thread_name != b.thread_name) {
+                return a.thread_name < b.thread_name;
+              }
+              return a.thread_id < b.thread_id;
+            });
+  SortTotals(stats.category_totals);
+  SortTotals(stats.named_event_totals);
+  return stats;
+}
+
+std::vector<ProfilerFrameStats> evo_engine::BuildProfilerFrameStatsHistory(
+    const std::vector<ProfilerFrameSnapshot>& snapshots) {
+  std::vector<ProfilerFrameStats> stats;
+  stats.reserve(snapshots.size());
+  for (const auto& snapshot : snapshots) {
+    stats.emplace_back(BuildProfilerFrameStats(snapshot));
+  }
+  return stats;
+}
+
+bool evo_engine::ExportProfilerChromeTrace(const std::filesystem::path& path,
+                                           const std::vector<ProfilerFrameSnapshot>& snapshots, std::string* error) {
+  if (path.empty()) {
+    if (error) {
+      *error = "Profiler trace export path is empty.";
+    }
+    return false;
+  }
+
+  std::error_code filesystem_error;
+  const auto parent = path.parent_path();
+  if (!parent.empty()) {
+    std::filesystem::create_directories(parent, filesystem_error);
+    if (filesystem_error) {
+      if (error) {
+        *error = filesystem_error.message();
+      }
+      return false;
+    }
+  }
+
+  std::ofstream stream(path);
+  if (!stream.is_open()) {
+    if (error) {
+      *error = "Failed to open profiler trace export file.";
+    }
+    return false;
+  }
+
+  stream << "{\"traceEvents\":[";
+  bool first_event = true;
+  double frame_start_ms = 0.0;
+  for (const auto& frame : snapshots) {
+    for (const auto& event : frame.events) {
+      if (!first_event) {
+        stream << ',';
+      }
+      first_event = false;
+      const auto timestamp_us = static_cast<uint64_t>((frame_start_ms + event.start_ms) * 1000.0);
+      const auto duration_us = static_cast<uint64_t>(event.duration_ms * 1000.0);
+      stream << "{\"name\":\"" << JsonEscape(event.name) << "\",\"cat\":\"" << JsonEscape(event.category)
+             << "\",\"ph\":\"X\",\"ts\":" << timestamp_us << ",\"dur\":" << duration_us
+             << ",\"pid\":1,\"tid\":" << event.thread_id << ",\"args\":{\"frame\":" << frame.frame_index
+             << ",\"thread\":\"" << JsonEscape(event.thread_name) << "\"}}";
+    }
+    frame_start_ms += frame.duration_ms;
+  }
+  stream << "]}";
+  if (!stream.good()) {
+    if (error) {
+      *error = "Failed while writing profiler trace export file.";
+    }
+    return false;
+  }
+  return true;
+}
 
 Profiler& Profiler::GetInstance() {
   static Profiler profiler;
@@ -82,6 +273,13 @@ void Profiler::Reset() {
   state.frame_history.clear();
   state.thread_names.clear();
   g_active_scopes.clear();
+}
+
+void Profiler::ClearFrameHistory() {
+  auto& state = State();
+  std::lock_guard lock(state.mutex);
+  state.completed_events.clear();
+  state.frame_history.clear();
 }
 
 void Profiler::SetMaxFrameHistory(const size_t max_frame_history) {
@@ -207,6 +405,18 @@ std::vector<ProfilerFrameSnapshot> Profiler::GetFrameHistorySnapshot() const {
   const auto& state = State();
   std::lock_guard lock(state.mutex);
   return {state.frame_history.begin(), state.frame_history.end()};
+}
+
+ProfilerFrameStats Profiler::GetLatestFrameStatsSnapshot() const {
+  return BuildProfilerFrameStats(GetLatestFrameSnapshot());
+}
+
+std::vector<ProfilerFrameStats> Profiler::GetFrameStatsHistorySnapshot() const {
+  return BuildProfilerFrameStatsHistory(GetFrameHistorySnapshot());
+}
+
+bool Profiler::ExportChromeTrace(const std::filesystem::path& path, std::string* error) const {
+  return ExportProfilerChromeTrace(path, GetFrameHistorySnapshot(), error);
 }
 
 ProfilerScope::ProfilerScope(const std::string& name, const std::string& category)

--- a/EvoEngine_SDK/src/ProjectManager.cpp
+++ b/EvoEngine_SDK/src/ProjectManager.cpp
@@ -2,6 +2,7 @@
 #include "Application.hpp"
 #include "EditorLayer.hpp"
 #include "PathUtils.hpp"
+#include "Profiler.hpp"
 #include "Scene.hpp"
 #include "TransformGraph.hpp"
 #include "WindowLayer.hpp"
@@ -336,6 +337,7 @@ void ProjectManager::SetupDefaultScene() {
   if (ArmSceneLoadingPopupBeforeSetup()) {
     return;
   }
+  const ProfilerScope profiler_scope("ProjectManager::SetupDefaultScene", "Scene Load");
   auto& project_manager = GetInstance();
   project_manager.loading_status_ = "Loading start scene...";
   const auto setup_start = LoadingClock::now();
@@ -373,6 +375,7 @@ void ProjectManager::SetupDefaultScene() {
       LogLoadingDuration("Scene post-load actions", post_load_start);
       project_manager.loading_status_ = "Synchronizing scene transforms...";
       const auto transform_start = LoadingClock::now();
+      const ProfilerScope transform_scope("ProjectManager::SceneTransformSync", "Scene Sync");
       TransformGraph::CalculateTransformGraphs(scene);
       LogLoadingDuration("Scene transform graph sync", transform_start);
     }
@@ -400,6 +403,7 @@ void ProjectManager::SetupDefaultScene() {
       LogLoadingDuration("New-scene actions", customizer_start);
       project_manager.loading_status_ = "Synchronizing scene transforms...";
       const auto transform_start = LoadingClock::now();
+      const ProfilerScope transform_scope("ProjectManager::SceneTransformSync", "Scene Sync");
       TransformGraph::CalculateTransformGraphs(scene);
       LogLoadingDuration("Scene transform graph sync", transform_start);
     }
@@ -529,6 +533,7 @@ ProjectLaunchMetadata ProjectManager::GetProjectLaunchMetadata() {
 }
 
 void ProjectManager::LoadAllPendingAssets() {
+  const ProfilerScope profiler_scope("ProjectManager::LoadAllPendingAssets", "Asset Load");
   auto& project_manager = GetInstance();
   if (project_manager.pending_assets.empty()) {
     return;
@@ -567,6 +572,7 @@ void ProjectManager::LoadAllPendingAssets() {
   }
 
   const auto blocking_load_start = LoadingClock::now();
+  const ProfilerScope blocking_load_scope("ProjectManager::BlockingProjectAssetLoad", "Asset Load");
   for (const auto& handle : blocking_handles) {
     AssetManager::GetAssetImpl(handle);
   }
@@ -630,6 +636,7 @@ bool ProjectManager::IsValidAssetFileName(const std::filesystem::path& path) {
 }
 
 void ProjectManager::GetOrCreateProject(const std::filesystem::path& path) {
+  const ProfilerScope profiler_scope("ProjectManager::GetOrCreateProject", "Project");
   auto& project_manager = GetInstance();
   auto project_absolute_path = std::filesystem::absolute(path);
   if (std::filesystem::is_directory(project_absolute_path)) {
@@ -710,6 +717,7 @@ void ProjectManager::SetActionAfterNewScene(const std::function<void(const std::
 }
 
 void ProjectManager::ScanAssets() {
+  const ProfilerScope profiler_scope("ProjectManager::ScanAssets", "Asset Load");
   auto& project_manager = GetInstance();
   project_manager.loading_status_ = "Scanning assets...";
   const auto scan_start = LoadingClock::now();

--- a/EvoEngine_SDK/src/RenderLayer.cpp
+++ b/EvoEngine_SDK/src/RenderLayer.cpp
@@ -11,6 +11,7 @@
 #include "Particles.hpp"
 #include "Platform.hpp"
 #include "PostProcessingStack.hpp"
+#include "Profiler.hpp"
 #include "ProjectManager.hpp"
 #include "Resources.hpp"
 #include "Shader.hpp"
@@ -996,6 +997,7 @@ void RenderLayer::ClearAllCameras() const {
 }
 
 void RenderLayer::PrepareForRendering() {
+  const ProfilerScope profiler_scope("RenderLayer::PrepareForRendering", "Render");
   const auto scene = GetScene();
   PrepareSceneForRendering(scene);
 }
@@ -1004,6 +1006,7 @@ void RenderLayer::PrepareSceneForRendering(const std::shared_ptr<Scene>& scene, 
                                            const bool update_editor_selection, const bool update_ray_tracing) {
   if (!scene)
     return;
+  const ProfilerScope profiler_scope("RenderLayer::PrepareSceneForRendering", "Render");
   const auto current_frame_index = Platform::GetCurrentFrameIndex();
   auto& graphics = Platform::GetInstance();
   graphics.prim_count[current_frame_index] = 0;
@@ -1078,6 +1081,7 @@ void RenderLayer::RenderSceneToCameraImmediately(const std::shared_ptr<Scene>& s
 }
 
 void RenderLayer::RenderAll() {
+  const ProfilerScope profiler_scope("RenderLayer::RenderAll", "Render");
   const auto current_frame_index = Platform::GetCurrentFrameIndex();
   const auto current_render_instances = render_instances_list_[current_frame_index];
   PreparePointAndSpotLightShadowMap();
@@ -1592,6 +1596,7 @@ void RenderLayer::PreparePointAndSpotLightShadowMap() const {
 
 bool RenderLayer::UpdateRenderInstanceStorage(const std::shared_ptr<Scene>& scene, const uint32_t current_frame_index,
                                               const bool include_editor_cameras, const bool update_editor_selection) {
+  const ProfilerScope profiler_scope("RenderLayer::UpdateRenderInstanceStorage", "Render");
   auto lod_center = glm::vec3(0.f);
   float lod_max_distance = FLT_MAX;
   bool lod_set = false;
@@ -1772,6 +1777,7 @@ void RenderLayer::PrepareEnvironmentalBrdfLut() {
 }
 void RenderLayer::RenderToCamera(const GlobalTransform& camera_global_transform, const std::shared_ptr<Camera>& camera,
                                  const bool immediate) const {
+  const ProfilerScope profiler_scope("RenderLayer::RenderToCamera", "Render");
   const auto current_frame_index = Platform::GetCurrentFrameIndex();
   const auto current_render_instances = render_instances_list_[current_frame_index];
   const int camera_index = current_render_instances->GetCameraIndex(camera->GetHandle());
@@ -2193,6 +2199,7 @@ void RenderLayer::RenderToCamera(const GlobalTransform& camera_global_transform,
 
 void RenderLayer::RenderToCameraRayTracing(const GlobalTransform& camera_global_transform,
                                            const std::shared_ptr<Camera>& camera) const {
+  const ProfilerScope profiler_scope("RenderLayer::RenderToCameraRayTracing", "Render");
   const auto current_frame_index = Platform::GetCurrentFrameIndex();
   const auto current_render_instances = render_instances_list_[current_frame_index];
   const int camera_index = current_render_instances->GetCameraIndex(camera->GetHandle());
@@ -2225,6 +2232,7 @@ void RenderLayer::RenderToCameraRayTracing(const GlobalTransform& camera_global_
 }
 
 void RenderLayer::PreUpdate() {
+  const ProfilerScope profiler_scope("RenderLayer::PreUpdate", "Render");
   const auto scene = GetScene();
   if (!scene)
     return;

--- a/EvoEngine_SDK/src/TaskRuntime.cpp
+++ b/EvoEngine_SDK/src/TaskRuntime.cpp
@@ -1,5 +1,7 @@
 #include "TaskRuntime.hpp"
 
+#include "Profiler.hpp"
+
 #include <algorithm>
 #include <chrono>
 #include <iostream>
@@ -135,6 +137,7 @@ void TaskRuntime::Initialize(const TaskRuntimeSettings& settings) {
   completed_task_size_ = 0;
   failed_task_size_ = 0;
   main_thread_id_ = std::this_thread::get_id();
+  Profiler::GetInstance().RegisterThread("MainThread");
   StartExecutor(worker_executor_, std::max<size_t>(1, settings.worker_thread_size), "Worker");
   StartExecutor(asset_io_executor_, settings.asset_io_thread_size, "AssetIo");
   StartExecutor(gpu_executor_, settings.gpu_thread_size, "Gpu");
@@ -432,7 +435,9 @@ void TaskRuntime::StartExecutor(ExecutorState& executor, const size_t thread_siz
   executor.name = name;
   executor.stopping = false;
   for (size_t i = 0; i < thread_size; ++i) {
-    executor.threads.emplace_back(std::make_unique<std::thread>([this, &executor]() {
+    const auto thread_name = name + "-" + std::to_string(i);
+    executor.threads.emplace_back(std::make_unique<std::thread>([this, &executor, thread_name]() {
+      Profiler::GetInstance().RegisterThread(thread_name);
       ExecutorLoop(executor);
     }));
   }
@@ -575,7 +580,10 @@ void TaskRuntime::RunTask(const TaskHandle& handle, const TaskExecutorType execu
   const auto previous_executor = g_current_executor;
   g_current_task_runtime = this;
   g_current_executor = executor;
+  const std::string task_name =
+      options.debug_name.empty() ? std::string(ExecutorName(executor)) + " Task" : options.debug_name;
   try {
+    const ProfilerScope profiler_scope(task_name, "Task");
     if (!cancellation_token.IsCancellationRequested() && function) {
       function();
     }

--- a/EvoEngine_Tests/CMakeLists.txt
+++ b/EvoEngine_Tests/CMakeLists.txt
@@ -17,6 +17,7 @@ file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Rendering" EVOENGINE_TEST_SCRIPT
 
 add_executable(EvoEngine_Tests
 	Core/TaskRuntimeTest.cpp
+	Core/ProfilerTest.cpp
 	Core/AssetManagerTest.cpp
 	Core/DemoSceneTest.cpp
 	Core/FileManagerTest.cpp
@@ -60,6 +61,11 @@ gtest_discover_tests(EvoEngine_Tests
 	WORKING_DIRECTORY "$<TARGET_FILE_DIR:EvoEngine_Tests>"
 	TEST_FILTER TaskRuntime.*
 	PROPERTIES LABELS "core,jobs"
+	)
+gtest_discover_tests(EvoEngine_Tests
+	WORKING_DIRECTORY "$<TARGET_FILE_DIR:EvoEngine_Tests>"
+	TEST_FILTER Profiler.*
+	PROPERTIES LABELS "core,profiler,jobs"
 	)
 gtest_discover_tests(EvoEngine_Tests
 	WORKING_DIRECTORY "$<TARGET_FILE_DIR:EvoEngine_Tests>"
@@ -121,6 +127,17 @@ if(TARGET DemoApp)
 	set(EVOENGINE_DEMOAPP_SMOKE_TEST_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/DemoAppSmokeTest.run.yaml")
 	file(WRITE "${EVOENGINE_DEMOAPP_SMOKE_TEST_CONFIG}"
 "mode: smoke_test
+application_mode: Editor
+demo_setup: Rendering
+frames_after_play: 100
+max_load_frames: 30000
+max_play_frames: 1000
+exit_on_complete: true
+")
+	set(EVOENGINE_DEMOAPP_PLAYER_SMOKE_TEST_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/DemoAppPlayerSmokeTest.run.yaml")
+	file(WRITE "${EVOENGINE_DEMOAPP_PLAYER_SMOKE_TEST_CONFIG}"
+"mode: smoke_test
+application_mode: Player
 demo_setup: Rendering
 frames_after_play: 100
 max_load_frames: 30000
@@ -135,6 +152,15 @@ exit_on_complete: true
 		PROPERTIES
 		WORKING_DIRECTORY "$<TARGET_FILE_DIR:DemoApp>"
 		LABELS "render,gpu,app"
+		TIMEOUT 240
+		)
+	add_test(NAME DemoApp.PlayerModePlayLoadedScene100Frames
+		COMMAND $<TARGET_FILE:DemoApp> --run-config "${EVOENGINE_DEMOAPP_PLAYER_SMOKE_TEST_CONFIG}"
+		)
+	set_tests_properties(DemoApp.PlayerModePlayLoadedScene100Frames
+		PROPERTIES
+		WORKING_DIRECTORY "$<TARGET_FILE_DIR:DemoApp>"
+		LABELS "render,gpu,app,player"
 		TIMEOUT 240
 		)
 endif()

--- a/EvoEngine_Tests/Core/LauncherUtilsTest.cpp
+++ b/EvoEngine_Tests/Core/LauncherUtilsTest.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include "AppBootstrap.hpp"
 #include "LauncherUtils.hpp"
 
 #include <chrono>
@@ -78,6 +79,18 @@ TEST(LauncherUtils, BuildsProjectMetadataFromSelectedPackages) {
   EXPECT_EQ(metadata.application_name, "NewProject");
   EXPECT_EQ(metadata.preferred_editor, "EvoEngineEditor");
   EXPECT_EQ(metadata.startup_runtime_packages, selected_packages);
+}
+
+TEST(LauncherUtils, ApplicationModeNamesAndArgumentsAreStable) {
+  EXPECT_EQ(ParseApplicationModeName("Editor"), ApplicationMode::Editor);
+  EXPECT_EQ(ParseApplicationModeName("player"), ApplicationMode::Player);
+  EXPECT_EQ(ParseApplicationModeName("Headless"), ApplicationMode::Headless);
+  EXPECT_STREQ(GetApplicationModeName(ApplicationMode::Editor), "Editor");
+  EXPECT_STREQ(GetApplicationModeName(ApplicationMode::Player), "Player");
+  EXPECT_STREQ(GetApplicationModeName(ApplicationMode::Headless), "Headless");
+  EXPECT_STREQ(GetApplicationModeArgument(ApplicationMode::Editor), "--editor");
+  EXPECT_STREQ(GetApplicationModeArgument(ApplicationMode::Player), "--player");
+  EXPECT_STREQ(GetApplicationModeArgument(ApplicationMode::Headless), "--headless");
 }
 
 TEST(LauncherUtils, ValidatesProjectNamesAndCreatePaths) {

--- a/EvoEngine_Tests/Core/ProfilerTest.cpp
+++ b/EvoEngine_Tests/Core/ProfilerTest.cpp
@@ -1,0 +1,99 @@
+#include "Profiler.hpp"
+#include "TaskRuntime.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+
+using namespace evo_engine;
+
+namespace {
+bool HasEvent(const ProfilerFrameSnapshot& snapshot, const std::string& name, const std::string& category) {
+  return std::any_of(snapshot.events.begin(), snapshot.events.end(), [&](const ProfilerScopeEvent& event) {
+    return event.name == name && event.category == category;
+  });
+}
+
+TaskRuntimeSettings ProfilerRuntimeSettings() {
+  TaskRuntimeSettings settings;
+  settings.worker_thread_size = 1;
+  settings.asset_io_thread_size = 0;
+  settings.gpu_thread_size = 0;
+  settings.render_thread_size = 0;
+  settings.background_thread_size = 0;
+  return settings;
+}
+}  // namespace
+
+TEST(Profiler, CapturesScopedEventsInFrame) {
+  auto& profiler = Profiler::GetInstance();
+  profiler.SetEnabled(true);
+  profiler.Reset();
+  profiler.RegisterThread("TestMain");
+
+  {
+    const ProfilerFrameScope frame;
+    const ProfilerScope scope("UnitScope", "Unit");
+  }
+
+  const auto snapshot = profiler.GetLatestFrameSnapshot();
+  ASSERT_EQ(snapshot.frame_index, 1);
+  ASSERT_EQ(snapshot.events.size(), 1);
+  EXPECT_EQ(snapshot.events.front().name, "UnitScope");
+  EXPECT_EQ(snapshot.events.front().category, "Unit");
+  EXPECT_EQ(snapshot.events.front().thread_name, "TestMain");
+  EXPECT_GE(snapshot.events.front().duration_ms, 0.0);
+  EXPECT_GE(snapshot.events.front().start_ms, 0.0);
+}
+
+TEST(Profiler, KeepsBoundedFrameHistory) {
+  auto& profiler = Profiler::GetInstance();
+  profiler.SetEnabled(true);
+  profiler.Reset();
+  profiler.SetMaxFrameHistory(2);
+
+  {
+    const ProfilerFrameScope frame;
+  }
+  {
+    const ProfilerFrameScope frame;
+  }
+  {
+    const ProfilerFrameScope frame;
+  }
+
+  const auto history = profiler.GetFrameHistorySnapshot();
+  ASSERT_EQ(history.size(), 2);
+  EXPECT_EQ(history.front().frame_index, 2);
+  EXPECT_EQ(history.back().frame_index, 3);
+}
+
+TEST(Profiler, CapturesTaskRuntimeExecutorScopes) {
+  auto& profiler = Profiler::GetInstance();
+  profiler.SetEnabled(true);
+  profiler.Reset();
+  profiler.SetMaxFrameHistory(8);
+
+  TaskRuntime runtime;
+  runtime.Initialize(ProfilerRuntimeSettings());
+
+  TaskOptions options;
+  options.executor = TaskExecutorType::Worker;
+  options.debug_name = "ProfiledTask";
+  {
+    const ProfilerFrameScope frame;
+    const auto task = runtime.Schedule({}, options, []() {
+      const ProfilerScope nested_scope("NestedWork", "Unit");
+    });
+    runtime.Wait(task);
+  }
+  runtime.Shutdown();
+
+  const auto snapshot = profiler.GetLatestFrameSnapshot();
+  EXPECT_TRUE(HasEvent(snapshot, "ProfiledTask", "Task"));
+  EXPECT_TRUE(HasEvent(snapshot, "NestedWork", "Unit"));
+  EXPECT_TRUE(std::any_of(snapshot.events.begin(), snapshot.events.end(), [](const ProfilerScopeEvent& event) {
+    return event.name == "ProfiledTask" && event.thread_name.rfind("Worker-", 0) == 0;
+  }));
+}

--- a/EvoEngine_Tests/Core/ProfilerTest.cpp
+++ b/EvoEngine_Tests/Core/ProfilerTest.cpp
@@ -4,6 +4,10 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
 #include <string>
 
 using namespace evo_engine;
@@ -15,6 +19,14 @@ bool HasEvent(const ProfilerFrameSnapshot& snapshot, const std::string& name, co
   });
 }
 
+const ProfilerAggregateTotal* FindTotal(const std::vector<ProfilerAggregateTotal>& totals, const std::string& name,
+                                        const std::string& category) {
+  const auto search = std::find_if(totals.begin(), totals.end(), [&](const ProfilerAggregateTotal& total) {
+    return total.name == name && total.category == category;
+  });
+  return search == totals.end() ? nullptr : &*search;
+}
+
 TaskRuntimeSettings ProfilerRuntimeSettings() {
   TaskRuntimeSettings settings;
   settings.worker_thread_size = 1;
@@ -24,6 +36,27 @@ TaskRuntimeSettings ProfilerRuntimeSettings() {
   settings.background_thread_size = 0;
   return settings;
 }
+
+class TempProfilerDirectory {
+ public:
+  TempProfilerDirectory() {
+    const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    root_ = std::filesystem::temp_directory_path() / ("EvoEngineProfilerTest_" + std::to_string(now));
+    std::filesystem::create_directories(root_);
+  }
+
+  ~TempProfilerDirectory() {
+    std::error_code error;
+    std::filesystem::remove_all(root_, error);
+  }
+
+  [[nodiscard]] std::filesystem::path RootPath() const {
+    return root_;
+  }
+
+ private:
+  std::filesystem::path root_;
+};
 }  // namespace
 
 TEST(Profiler, CapturesScopedEventsInFrame) {
@@ -69,6 +102,30 @@ TEST(Profiler, KeepsBoundedFrameHistory) {
   EXPECT_EQ(history.back().frame_index, 3);
 }
 
+TEST(Profiler, ClearsFrameHistoryWithoutDisablingCapture) {
+  auto& profiler = Profiler::GetInstance();
+  profiler.SetEnabled(true);
+  profiler.Reset();
+
+  {
+    const ProfilerFrameScope frame;
+    const ProfilerScope scope("BeforeClear", "Unit");
+  }
+  ASSERT_FALSE(profiler.GetFrameHistorySnapshot().empty());
+
+  profiler.ClearFrameHistory();
+  EXPECT_TRUE(profiler.GetFrameHistorySnapshot().empty());
+  EXPECT_TRUE(profiler.IsEnabled());
+
+  {
+    const ProfilerFrameScope frame;
+    const ProfilerScope scope("AfterClear", "Unit");
+  }
+  const auto snapshot = profiler.GetLatestFrameSnapshot();
+  ASSERT_FALSE(snapshot.events.empty());
+  EXPECT_EQ(snapshot.events.front().name, "AfterClear");
+}
+
 TEST(Profiler, CapturesTaskRuntimeExecutorScopes) {
   auto& profiler = Profiler::GetInstance();
   profiler.SetEnabled(true);
@@ -96,4 +153,71 @@ TEST(Profiler, CapturesTaskRuntimeExecutorScopes) {
   EXPECT_TRUE(std::any_of(snapshot.events.begin(), snapshot.events.end(), [](const ProfilerScopeEvent& event) {
     return event.name == "ProfiledTask" && event.thread_name.rfind("Worker-", 0) == 0;
   }));
+}
+
+TEST(Profiler, BuildsFrameStatsForThreadLanesAndTotals) {
+  ProfilerFrameSnapshot snapshot;
+  snapshot.frame_index = 7;
+  snapshot.duration_ms = 16.0;
+  snapshot.events = {
+      {7, 2, "Worker-0", "AssetFinalize", "Asset", 0, 4.0, 5.0},
+      {7, 1, "MainThread", "Application::Update", "Frame", 0, 0.0, 7.0},
+      {7, 1, "MainThread", "RenderSubmit", "Render", 0, 8.0, 3.0},
+      {7, 1, "MainThread", "Application::Update", "Frame", 0, 12.0, 1.0},
+  };
+
+  const auto stats = BuildProfilerFrameStats(snapshot);
+  EXPECT_EQ(stats.frame_index, 7);
+  EXPECT_DOUBLE_EQ(stats.duration_ms, 16.0);
+  EXPECT_EQ(stats.event_count, 4);
+  EXPECT_DOUBLE_EQ(stats.total_event_ms, 16.0);
+  EXPECT_DOUBLE_EQ(stats.max_event_ms, 7.0);
+
+  ASSERT_EQ(stats.thread_lanes.size(), 2);
+  EXPECT_EQ(stats.thread_lanes[0].thread_name, "MainThread");
+  EXPECT_EQ(stats.thread_lanes[0].events.size(), 3);
+  EXPECT_DOUBLE_EQ(stats.thread_lanes[0].total_ms, 11.0);
+  EXPECT_EQ(stats.thread_lanes[0].events.front().name, "Application::Update");
+  EXPECT_EQ(stats.thread_lanes[1].thread_name, "Worker-0");
+  EXPECT_DOUBLE_EQ(stats.thread_lanes[1].total_ms, 5.0);
+
+  const auto* frame_total = FindTotal(stats.category_totals, "Frame", "Frame");
+  ASSERT_NE(frame_total, nullptr);
+  EXPECT_EQ(frame_total->count, 2);
+  EXPECT_DOUBLE_EQ(frame_total->total_ms, 8.0);
+  EXPECT_DOUBLE_EQ(frame_total->average_ms, 4.0);
+  EXPECT_DOUBLE_EQ(frame_total->max_ms, 7.0);
+
+  const auto* update_total = FindTotal(stats.named_event_totals, "Application::Update", "Frame");
+  ASSERT_NE(update_total, nullptr);
+  EXPECT_EQ(update_total->count, 2);
+  EXPECT_DOUBLE_EQ(update_total->total_ms, 8.0);
+  EXPECT_DOUBLE_EQ(update_total->average_ms, 4.0);
+  EXPECT_DOUBLE_EQ(update_total->max_ms, 7.0);
+}
+
+TEST(Profiler, ExportsChromeTraceJson) {
+  ProfilerFrameSnapshot snapshot;
+  snapshot.frame_index = 3;
+  snapshot.duration_ms = 12.0;
+  snapshot.events = {
+      {3, 7, "MainThread", "Scene \"Update\"", "Scene", 0, 1.0, 2.5},
+      {3, 8, "Worker-0", "Asset\nFinalize", "Asset Finalize", 1, 4.0, 3.0},
+  };
+
+  TempProfilerDirectory temp;
+  const auto trace_path = temp.RootPath() / "trace.json";
+  std::string error;
+  ASSERT_TRUE(ExportProfilerChromeTrace(trace_path, {snapshot}, &error)) << error;
+
+  std::ifstream stream(trace_path);
+  std::stringstream buffer;
+  buffer << stream.rdbuf();
+  const auto json = buffer.str();
+  EXPECT_NE(json.find("\"traceEvents\""), std::string::npos);
+  EXPECT_NE(json.find("\"ph\":\"X\""), std::string::npos);
+  EXPECT_NE(json.find("Scene \\\"Update\\\""), std::string::npos);
+  EXPECT_NE(json.find("Asset\\nFinalize"), std::string::npos);
+  EXPECT_NE(json.find("\"tid\":7"), std::string::npos);
+  EXPECT_NE(json.find("\"frame\":3"), std::string::npos);
 }

--- a/EvoEngine_Tests/Launcher/launcher_process_smoke.py
+++ b/EvoEngine_Tests/Launcher/launcher_process_smoke.py
@@ -69,6 +69,28 @@ def main() -> int:
             finally:
                 kill_process(editor)
 
+        def editor_player_mode_opens_existing_project() -> None:
+            editor = subprocess.Popen([str(args.editor), "--project", str(project_path), "--player"],
+                                      cwd=args.editor.parent)
+            try:
+                wait_for_window(editor, "Player project", timeout=20)
+            finally:
+                kill_process(editor)
+
+        def editor_headless_mode_initializes_project() -> None:
+            with tempfile.TemporaryDirectory(prefix="EvoEngineLauncherHeadlessSmoke_") as temp_dir:
+                metadata_only_project = write_metadata_only_project(Path(temp_dir))
+                editor = subprocess.Popen([str(args.editor), "--project", str(metadata_only_project), "--headless"],
+                                          cwd=args.editor.parent)
+                try:
+                    wait_until(
+                        "headless metadata-only project start_scene_handle",
+                        lambda: has_start_scene_handle(metadata_only_project),
+                        timeout=20,
+                    )
+                finally:
+                    kill_process(editor)
+
         def editor_creates_metadata_only_start_scene() -> None:
             with tempfile.TemporaryDirectory(prefix="EvoEngineLauncherProcessSmoke_") as temp_dir:
                 metadata_only_project = write_metadata_only_project(Path(temp_dir))
@@ -98,6 +120,8 @@ def main() -> int:
 
         run_subtest("EditorWithoutProject.SpawnsLauncher", editor_without_project_spawns_launcher)
         run_subtest("EditorWithProject.OpensWindow", editor_opens_existing_project)
+        run_subtest("EditorPlayerMode.OpensWindow", editor_player_mode_opens_existing_project)
+        run_subtest("EditorHeadlessMode.InitializesProject", editor_headless_mode_initializes_project)
         run_subtest("MetadataOnlyProject.PersistsStartScene", editor_creates_metadata_only_start_scene)
         run_subtest("LauncherOpenProjectHook.SpawnsEditor", launcher_open_project_hook_spawns_editor)
         return 0


### PR DESCRIPTION
﻿## Summary
- Add editor-facing CPU profiler aggregation, capture controls, frame history inspection, and Chrome trace export.
- Add an editor Profiler panel with frame timing, per-thread lanes, event details, and aggregate views.
- Instrument application frame phases, scene load/sync, asset load/finalization, and render phases.
- Remove the Headless start mode option from the launcher UI while keeping direct command-line headless support.

## Why
This starts the Unity-style real-time profiling workflow for EvoEngine by exposing CPU-thread timing data in the editor while preserving offline trace inspection for deeper analysis.

## Notes
- Fixed a console message vector race found during DemoApp editor smoke testing by snapshotting console messages under the existing mutex before rendering.
- Launcher project start mode now exposes only Editor and Player.

## Validation
- `python Scripts\format_cpp.py --check --root EvoEngine_App\src --root EvoEngine_App\include --root EvoEngine_SDK\include --root EvoEngine_SDK\src --root EvoEngine_Tests`
- `cmake --build out/build/vs2026-x64 --config RelWithDebInfo --target EvoEngine_Tests EvoEngineEditor EvoEngineLauncher DemoApp`
- `ctest --test-dir out/build/vs2026-x64 -C RelWithDebInfo -R "Launcher|Profiler|TaskRuntime|DemoApp\." --output-on-failure`
