### PR TITLE
Fix project browser hierarchy reveal

### DIFF
--- a/EvoEngine_SDK/include/Editor/ProjectContentBrowserPanel.hpp
+++ b/EvoEngine_SDK/include/Editor/ProjectContentBrowserPanel.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -23,12 +24,14 @@ class ProjectContentBrowserPanel final : public EditorPanel {
  private:
   enum class SelectedItemType { None, Folder, File };
 
-  void FolderHierarchyHelper(const std::shared_ptr<EditorLayer>& editor_layer, const std::shared_ptr<Folder>& folder);
+  void FolderHierarchyHelper(const std::shared_ptr<EditorLayer>& editor_layer, const std::shared_ptr<Folder>& folder,
+                             const std::shared_ptr<Folder>& reveal_folder);
   void DrawToolbar(const std::shared_ptr<Folder>& current_folder);
   void DrawBreadcrumbs(const std::shared_ptr<Folder>& current_folder);
   void DrawSearchResults(const std::shared_ptr<EditorLayer>& editor_layer, const std::shared_ptr<Folder>& root_folder,
                          bool& updated);
   void NavigateToFolder(const std::shared_ptr<Folder>& folder, bool add_history = true);
+  void RequestHierarchyReveal(const std::shared_ptr<Folder>& folder);
   void NavigateHistory(int offset);
   void SyncNavigationHistory(const std::shared_ptr<Folder>& current_folder);
 
@@ -47,6 +50,7 @@ class ProjectContentBrowserPanel final : public EditorPanel {
   float thumbnail_padding_ = 8.0f;
   float hierarchy_width_ = 200.0f;
   float content_width_ = 200.0f;
+  std::optional<Handle> hierarchy_reveal_target_;
   SelectedItemType selected_item_type_ = SelectedItemType::None;
   Handle selected_item_handle_ = 0;
   bool show_extension_ = false;

--- a/EvoEngine_SDK/src/ProjectContentBrowserPanel.cpp
+++ b/EvoEngine_SDK/src/ProjectContentBrowserPanel.cpp
@@ -225,6 +225,7 @@ void ProjectContentBrowserPanel::Draw(const std::shared_ptr<EditorLayer>& editor
         if (!current_focused_folder) {
           current_focused_folder = project_manager.assets_folder_;
           project_manager.current_focused_folder_ = current_focused_folder;
+          RequestHierarchyReveal(current_focused_folder);
         }
         SyncNavigationHistory(current_focused_folder);
         if (ImGui::BeginDragDropTarget()) {
@@ -250,7 +251,10 @@ void ProjectContentBrowserPanel::Draw(const std::shared_ptr<EditorLayer>& editor
         h = avail.y;
         ImGui::Splitter(true, 8.0, hierarchy_width_, content_width_, 32.0f, cell_size + 8.0f, h);
         ImGui::BeginChild("1", ImVec2(hierarchy_width_, h), true);
-        FolderHierarchyHelper(editor_layer, project_manager.assets_folder_);
+        const auto reveal_folder =
+            hierarchy_reveal_target_ ? FileManager::GetFolder(*hierarchy_reveal_target_) : nullptr;
+        FolderHierarchyHelper(editor_layer, project_manager.assets_folder_, reveal_folder);
+        hierarchy_reveal_target_.reset();
         ImGui::EndChild();
 
         ImGui::SameLine();
@@ -621,6 +625,7 @@ void ProjectContentBrowserPanel::NavigateToFolder(const std::shared_ptr<Folder>&
 
   auto& project_manager = ProjectManager::GetInstance();
   project_manager.current_focused_folder_ = folder;
+  RequestHierarchyReveal(folder);
   selected_item_type_ = SelectedItemType::None;
   selected_item_handle_ = 0;
   if (!add_history) {
@@ -637,6 +642,12 @@ void ProjectContentBrowserPanel::NavigateToFolder(const std::shared_ptr<Folder>&
   }
   folder_history_.emplace_back(handle);
   folder_history_index_ = folder_history_.size() - 1;
+}
+
+void ProjectContentBrowserPanel::RequestHierarchyReveal(const std::shared_ptr<Folder>& folder) {
+  if (folder) {
+    hierarchy_reveal_target_ = folder->GetHandle();
+  }
 }
 
 void ProjectContentBrowserPanel::NavigateHistory(const int offset) {
@@ -710,16 +721,18 @@ bool ProjectContentBrowserPanel::TextContainsCaseInsensitive(const std::string& 
 }
 
 void ProjectContentBrowserPanel::FolderHierarchyHelper(const std::shared_ptr<EditorLayer>& editor_layer,
-                                                       const std::shared_ptr<Folder>& folder) {
+                                                       const std::shared_ptr<Folder>& folder,
+                                                       const std::shared_ptr<Folder>& reveal_folder) {
   auto& project_manager = ProjectManager::GetInstance();
   auto focus_folder = project_manager.current_focused_folder_.lock();
-  if (focus_folder && folder->IsSelfOrAncestor(focus_folder->GetHandle())) {
+  const bool reveal_path = reveal_folder && reveal_folder->IsSelfOrAncestor(folder->GetHandle());
+  if (reveal_path) {
     ImGui::SetNextItemOpen(true, ImGuiCond_Always);
   }
   const bool opened = ImGui::TreeNodeEx(
       folder->name_.c_str(), ImGuiTreeNodeFlags_OpenOnArrow |
                                  (folder == focus_folder ? ImGuiTreeNodeFlags_Selected : ImGuiTreeNodeFlags_None));
-  if (folder == focus_folder) {
+  if (folder == reveal_folder) {
     ImGui::SetScrollHereY(0.35f);
   }
   if (ImGui::BeginDragDropTarget()) {
@@ -769,7 +782,7 @@ void ProjectContentBrowserPanel::FolderHierarchyHelper(const std::shared_ptr<Edi
   }
   if (opened) {
     for (const auto& i : folder->children_) {
-      FolderHierarchyHelper(editor_layer, i.second);
+      FolderHierarchyHelper(editor_layer, i.second, reveal_folder);
     }
     for (const auto& i : folder->files) {
       if (ImGui::TreeNodeEx((i.second->GetAssetFileName() + i.second->GetAssetExtension()).c_str(),


### PR DESCRIPTION
﻿## Summary
- Change Project panel hierarchy expansion and scrolling to a one-shot reveal request.
- Preserve explicit folder reveal behavior for titlebar/search navigation and README screenshot automation.
- Stop the Project panel from forcing the focused folder path open every frame during normal editor use.

## Why
The README screenshot layout needs to reveal `Models/Sponza/textures`, but the previous hierarchy behavior made focused folder expansion feel fixed in the normal editor. Users should be able to collapse the folder hierarchy after a reveal.

## Validation
- `python Scripts\format_cpp.py --check --root EvoEngine_SDK\include --root EvoEngine_SDK\src --root EvoEngine_App\src --root EvoEngine_Tests`
- `cmake --build out/build/vs2026-x64 --config RelWithDebInfo --target EvoEngineEditor DemoApp EvoEngine_Tests`
- `ctest --test-dir out/build/vs2026-x64 -C RelWithDebInfo -R "DemoApp\." --output-on-failure`
- `python Scripts\capture_readme_editor_screenshot.py --no-build --timeout 240`
