### PR TITLE
Prepare Slang migration shader cleanup

### DIFF
--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Compute/DynamicStrands/Fungus/FungusDiffusion_edge.comp
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Compute/DynamicStrands/Fungus/FungusDiffusion_edge.comp
@@ -33,11 +33,15 @@ layout(push_constant) uniform PUSH_CONSTANTS {
   float HL_threshold;
   uint treespace;
   float padding1;
-  mat4 matrixAw4;
-  mat4 matrixAb4;
-  mat4 matrixAc4;
-  mat4 matrixAm4;
+  vec4 matrixAw[3];
+  vec4 matrixAb[3];
+  vec4 matrixAc[3];
+  vec4 matrixAm[3];
 };
+
+mat3 unpackMat3(vec4 c0, vec4 c1, vec4 c2) {
+  return mat3(c0.xyz, c1.xyz, c2.xyz);
+}
 
 // void computeDiffusionWeights(vec3 source_pos, vec3 target_pos, float source_distance, float target_distance, float
 // max_b, float max_w,
@@ -55,9 +59,9 @@ layout(push_constant) uniform PUSH_CONSTANTS {
 //
 //   edge_dir /= d;
 //
-//   mat3 matrixAw = mat3(matrixAw4);
-//   mat3 matrixAb = mat3(matrixAb4);
-//   mat3 matrixAc = mat3(matrixAc4);
+//   mat3 matrixAw = unpackMat3(matrixAw[0], matrixAw[1], matrixAw[2]);
+//   mat3 matrixAb = unpackMat3(matrixAb[0], matrixAb[1], matrixAb[2]);
+//   mat3 matrixAc = unpackMat3(matrixAc[0], matrixAc[1], matrixAc[2]);
 //   //mat3 matrixAm = mat3(2.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1);
 //   mat3 matrixAm = mat3(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
 //
@@ -105,10 +109,10 @@ void computeDiffusionWeights(vec3 source_pos, vec3 target_pos, float source_dist
   // mat3 M_w = mat3(100.0, 0.0, 0.0, 0.0, 0.20, 0.0, 0.0, 0.0, 0.20);
   // mat3 M_b = mat3(100.0, 0.0, 0.0, 0.0, 0.20, 0.0, 0.0, 0.0, 0.20); //log
   if (global_parameter == 1) {
-    M_w = mat3(matrixAw4);
-    M_b = mat3(matrixAb4);
-    M_c = mat3(matrixAc4);
-    M_m = mat3(matrixAm4);
+    M_w = unpackMat3(matrixAw[0], matrixAw[1], matrixAw[2]);
+    M_b = unpackMat3(matrixAb[0], matrixAb[1], matrixAb[2]);
+    M_c = unpackMat3(matrixAc[0], matrixAc[1], matrixAc[2]);
+    M_m = unpackMat3(matrixAm[0], matrixAm[1], matrixAm[2]);
   }
 
   float rho2_w = max(dot(dvec * M_w, dvec), 0.0);
@@ -184,10 +188,10 @@ void computeDiffusionWeights_Tspace(vec3 source_pos, vec3 target_pos, float sour
   // mat3 M_w = mat3(100.0, 0.0, 0.0, 0.0, 0.20, 0.0, 0.0, 0.0, 0.20);
   // mat3 M_b = mat3(100.0, 0.0, 0.0, 0.0, 0.20, 0.0, 0.0, 0.0, 0.20); //log
   if (global_parameter == 1) {
-    M_w = mat3(matrixAw4);
-    M_b = mat3(matrixAb4);
-    M_c = mat3(matrixAc4);
-    M_m = mat3(matrixAm4);
+    M_w = unpackMat3(matrixAw[0], matrixAw[1], matrixAw[2]);
+    M_b = unpackMat3(matrixAb[0], matrixAb[1], matrixAb[2]);
+    M_c = unpackMat3(matrixAc[0], matrixAc[1], matrixAc[2]);
+    M_m = unpackMat3(matrixAm[0], matrixAm[1], matrixAm[2]);
 
      ////M_b = mat3(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 20.0); //For elm
      //M_b = mat3(1000.0, 0.0, 0.0, 0.0, 1000.0, 0.0, 0.0, 0.0, 1000.0);

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/AlphaShapeMeshing/SmallSegments/DirectionalLightShadowMap.mesh
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/AlphaShapeMeshing/SmallSegments/DirectionalLightShadowMap.mesh
@@ -74,7 +74,7 @@ void main() {
   [[unroll]]
   for (uint i = 0; i < uint(SMALL_SEGMENT_VERTEX_ITERATIONS); ++i) {
     uint vertex_index = laneID + i * WORKGROUP_SIZE;
-    if (vertex_index > SMALL_SEGMENT_SHADOW_MAP_VERTICES_SIZE)
+    if (vertex_index >= SMALL_SEGMENT_SHADOW_MAP_VERTICES_SIZE)
       break;
     vec3 vertex_position = shadow_map_positions[vertex_index];
 
@@ -84,7 +84,7 @@ void main() {
   [[unroll]]
   for (uint i = 0; i < uint(SMALL_SEGMENT_PRIMITIVE_ITERATIONS); ++i) {
     uint triangle_index = laneID + i * WORKGROUP_SIZE;
-    if (triangle_index <= SMALL_SEGMENT_SHADOW_MAP_TRIANGLE_SIZE) {
+    if (triangle_index < SMALL_SEGMENT_SHADOW_MAP_TRIANGLE_SIZE) {
       gl_PrimitiveTriangleIndicesEXT[triangle_index] = shadow_map_triangles[triangle_index];
     }
   }

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/AlphaShapeMeshing/SmallSegments/PointLightShadowMap.mesh
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/AlphaShapeMeshing/SmallSegments/PointLightShadowMap.mesh
@@ -74,7 +74,7 @@ void main() {
   [[unroll]]
   for (uint i = 0; i < uint(SMALL_SEGMENT_VERTEX_ITERATIONS); ++i) {
     uint vertex_index = laneID + i * WORKGROUP_SIZE;
-    if (vertex_index > SMALL_SEGMENT_SHADOW_MAP_VERTICES_SIZE)
+    if (vertex_index >= SMALL_SEGMENT_SHADOW_MAP_VERTICES_SIZE)
       break;
     vec3 vertex_position = shadow_map_positions[vertex_index];
 
@@ -84,7 +84,7 @@ void main() {
   [[unroll]]
   for (uint i = 0; i < uint(SMALL_SEGMENT_PRIMITIVE_ITERATIONS); ++i) {
     uint triangle_index = laneID + i * WORKGROUP_SIZE;
-    if (triangle_index <= SMALL_SEGMENT_SHADOW_MAP_TRIANGLE_SIZE) {
+    if (triangle_index < SMALL_SEGMENT_SHADOW_MAP_TRIANGLE_SIZE) {
       gl_PrimitiveTriangleIndicesEXT[triangle_index] = shadow_map_triangles[triangle_index];
     }
   }

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/AlphaShapeMeshing/SmallSegments/SpotLightShadowMap.mesh
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/AlphaShapeMeshing/SmallSegments/SpotLightShadowMap.mesh
@@ -74,7 +74,7 @@ void main() {
   [[unroll]]
   for (uint i = 0; i < uint(SMALL_SEGMENT_VERTEX_ITERATIONS); ++i) {
     uint vertex_index = laneID + i * WORKGROUP_SIZE;
-    if (vertex_index > SMALL_SEGMENT_SHADOW_MAP_VERTICES_SIZE)
+    if (vertex_index >= SMALL_SEGMENT_SHADOW_MAP_VERTICES_SIZE)
       break;
     vec3 vertex_position = shadow_map_positions[vertex_index];
 
@@ -84,7 +84,7 @@ void main() {
   [[unroll]]
   for (uint i = 0; i < uint(SMALL_SEGMENT_PRIMITIVE_ITERATIONS); ++i) {
     uint triangle_index = laneID + i * WORKGROUP_SIZE;
-    if (triangle_index <= SMALL_SEGMENT_SHADOW_MAP_TRIANGLE_SIZE) {
+    if (triangle_index < SMALL_SEGMENT_SHADOW_MAP_TRIANGLE_SIZE) {
       gl_PrimitiveTriangleIndicesEXT[triangle_index] = shadow_map_triangles[triangle_index];
     }
   }

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/Foliage/DirectionalLightShadowMap.mesh
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/Foliage/DirectionalLightShadowMap.mesh
@@ -23,23 +23,12 @@ layout(max_vertices = LEAF_VERTICES_SIZE, max_primitives = LEAF_TRIANGLE_SIZE) o
 const uint LEAF_VERTEX_ITERATIONS = ((LEAF_VERTICES_SIZE + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
 const uint LEAF_PRIMITIVE_ITERATIONS = ((LEAF_TRIANGLE_SIZE + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
 
-layout(location = 0) out MS_V_OUT {
-  vec3 FragPos;
-  vec3 Normal;
-  vec3 Tangent;
-  vec2 TexCoord;
-  vec4 Color;
-}
-ms_v_out[];
-
 struct Task {
   uint baseID;
   uint8_t deltaIDs[EXT_TASK_WORK_GROUP_INVOCATIONS];
 };
 
 vec3 positions[] = {vec3(-0.5, 0, -0.5), vec3(-0.5, 0, 0.5), vec3(0.5, 0, 0.5), vec3(0.5, 0, -0.5)};
-
-vec2 tex_coords[] = {vec2(0, 0), vec2(0, 1), vec2(1, 1), vec2(1, 0)};
 
 uvec3 triangles[] = {
     uvec3(0, 1, 2),
@@ -74,11 +63,6 @@ void main() {
       break;
     vec3 vertex_position = positions[vertex_index];
 
-    ms_v_out[vertex_index].FragPos = vec4(instance_matrix * vec4(vertex_position, 1.0f)).xyz;
-    ms_v_out[vertex_index].TexCoord = tex_coords[vertex_index];
-    ms_v_out[vertex_index].Normal = vec4(instance_matrix * vec4(0, 1, 0, 0)).xyz;
-    ms_v_out[vertex_index].Tangent = vec4(instance_matrix * vec4(0, 0, 1, 0)).xyz;
-    ms_v_out[vertex_index].Color = vec4(leaf.attachment_integrity, leaf.rotation_integrity, 0, 1);
     gl_MeshVerticesEXT[vertex_index].gl_Position = transform * vec4(vertex_position, 1.0f);
   }
 

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/Foliage/PointLightShadowMap.mesh
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/Foliage/PointLightShadowMap.mesh
@@ -23,23 +23,12 @@ layout(max_vertices = LEAF_VERTICES_SIZE, max_primitives = LEAF_TRIANGLE_SIZE) o
 const uint LEAF_VERTEX_ITERATIONS = ((LEAF_VERTICES_SIZE + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
 const uint LEAF_PRIMITIVE_ITERATIONS = ((LEAF_TRIANGLE_SIZE + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
 
-layout(location = 0) out MS_V_OUT {
-  vec3 FragPos;
-  vec3 Normal;
-  vec3 Tangent;
-  vec2 TexCoord;
-  vec4 Color;
-}
-ms_v_out[];
-
 struct Task {
   uint baseID;
   uint8_t deltaIDs[EXT_TASK_WORK_GROUP_INVOCATIONS];
 };
 
 vec3 positions[] = {vec3(-0.5, 0, -0.5), vec3(-0.5, 0, 0.5), vec3(0.5, 0, 0.5), vec3(0.5, 0, -0.5)};
-
-vec2 tex_coords[] = {vec2(0, 0), vec2(0, 1), vec2(1, 1), vec2(1, 0)};
 
 uvec3 triangles[] = {
     uvec3(0, 1, 2),
@@ -74,11 +63,6 @@ void main() {
       break;
     vec3 vertex_position = positions[vertex_index];
 
-    ms_v_out[vertex_index].FragPos = vec4(instance_matrix * vec4(vertex_position, 1.0f)).xyz;
-    ms_v_out[vertex_index].TexCoord = tex_coords[vertex_index];
-    ms_v_out[vertex_index].Normal = vec4(instance_matrix * vec4(0, 1, 0, 0)).xyz;
-    ms_v_out[vertex_index].Tangent = vec4(instance_matrix * vec4(0, 0, 1, 0)).xyz;
-    ms_v_out[vertex_index].Color = vec4(leaf.attachment_integrity, leaf.rotation_integrity, 0, 1);
     gl_MeshVerticesEXT[vertex_index].gl_Position = transform * vec4(vertex_position, 1.0f);
   }
 

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/Foliage/SpotLightShadowMap.mesh
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/Foliage/SpotLightShadowMap.mesh
@@ -23,23 +23,12 @@ layout(max_vertices = LEAF_VERTICES_SIZE, max_primitives = LEAF_TRIANGLE_SIZE) o
 const uint LEAF_VERTEX_ITERATIONS = ((LEAF_VERTICES_SIZE + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
 const uint LEAF_PRIMITIVE_ITERATIONS = ((LEAF_TRIANGLE_SIZE + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
 
-layout(location = 0) out MS_V_OUT {
-  vec3 FragPos;
-  vec3 Normal;
-  vec3 Tangent;
-  vec2 TexCoord;
-  vec4 Color;
-}
-ms_v_out[];
-
 struct Task {
   uint baseID;
   uint8_t deltaIDs[EXT_TASK_WORK_GROUP_INVOCATIONS];
 };
 
 vec3 positions[] = {vec3(-0.5, 0, -0.5), vec3(-0.5, 0, 0.5), vec3(0.5, 0, 0.5), vec3(0.5, 0, -0.5)};
-
-vec2 tex_coords[] = {vec2(0, 0), vec2(0, 1), vec2(1, 1), vec2(1, 0)};
 
 uvec3 triangles[] = {
     uvec3(0, 1, 2),
@@ -74,11 +63,6 @@ void main() {
       break;
     vec3 vertex_position = positions[vertex_index];
 
-    ms_v_out[vertex_index].FragPos = vec4(instance_matrix * vec4(vertex_position, 1.0f)).xyz;
-    ms_v_out[vertex_index].TexCoord = tex_coords[vertex_index];
-    ms_v_out[vertex_index].Normal = vec4(instance_matrix * vec4(0, 1, 0, 0)).xyz;
-    ms_v_out[vertex_index].Tangent = vec4(instance_matrix * vec4(0, 0, 1, 0)).xyz;
-    ms_v_out[vertex_index].Color = vec4(leaf.attachment_integrity, leaf.rotation_integrity, 0, 1);
     gl_MeshVerticesEXT[vertex_index].gl_Position = transform * vec4(vertex_position, 1.0f);
   }
 

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/KineticVoronoiMeshing/SegmentMeshlet/DirectionalLightShadowMap.mesh
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/KineticVoronoiMeshing/SegmentMeshlet/DirectionalLightShadowMap.mesh
@@ -26,15 +26,6 @@ layout(max_vertices = MAX_VERTEX_COUNT, max_primitives = MAX_PRIMITIVE_COUNT) ou
 
 const uint PRIMITIVE_ITERATIONS = ((MAX_PRIMITIVE_COUNT + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
 
-layout(location = 0) out MS_V_OUT {
-  vec3 FragPos;
-  vec3 Normal;
-  vec3 Tangent;
-  vec2 TexCoord;
-  vec4 Color;
-}
-ms_v_out[];
-
 struct Task {
   uint baseID;
   uint8_t deltaIDs[EXT_TASK_WORK_GROUP_INVOCATIONS];
@@ -52,15 +43,10 @@ uint laneID = gl_LocalInvocationID.x;
 
 #include "KineticVoronoiRenderingConstants.glsl"
 
-void SetUpTriangleVertex(uint vertex_index, in vec3 vertex_normal, in SegmentMeshletVertex segment_meshlet_vertex) {
+void SetUpTriangleVertex(uint vertex_index, in SegmentMeshletVertex segment_meshlet_vertex) {
   mat4 transform = EE_DIRECTIONAL_LIGHTS[EE_CAMERA_INDEX].light_space_matrix[EE_INSTANCE_INDEX];
 
   vec3 pos = segment_meshlet_vertex.x - fracture_distance * segment_meshlet_vertex.shift;
-  ms_v_out[vertex_index].FragPos = pos;
-
-  ms_v_out[vertex_index].Normal = vertex_normal;
-  ms_v_out[vertex_index].Tangent = vec3(0.0, 1.0, 0.0);     // TODO
-  ms_v_out[vertex_index].Color = vec4(1.0, 1.0, 1.0, 1.0);  // TODO
   gl_MeshVerticesEXT[vertex_index].gl_Position = transform * vec4(pos, 1.0);
 }
 
@@ -78,8 +64,7 @@ void main() {
       for (int j = 0; j < 3; j++) {
         uint global_vertex_index = tri.vertex_indices[j];
         SegmentMeshletVertex segment_meshlet_vertex = segment_meshlet_vertices[global_vertex_index];
-        vec3 normal = vec3(1, 0, 0);
-        SetUpTriangleVertex(j, normal, segment_meshlet_vertex);
+        SetUpTriangleVertex(j, segment_meshlet_vertex);
       }
     }
   }

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/KineticVoronoiMeshing/SegmentMeshlet/PointLightShadowMap.mesh
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/KineticVoronoiMeshing/SegmentMeshlet/PointLightShadowMap.mesh
@@ -27,15 +27,6 @@ layout(max_vertices = MAX_VERTEX_COUNT, max_primitives = MAX_PRIMITIVE_COUNT) ou
 const uint VERTEX_ITERATIONS = ((MAX_VERTEX_COUNT + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
 const uint PRIMITIVE_ITERATIONS = ((MAX_PRIMITIVE_COUNT + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
 
-layout(location = 0) out MS_V_OUT {
-  vec3 FragPos;
-  vec3 Normal;
-  vec3 Tangent;
-  vec2 TexCoord;
-  vec4 Color;
-}
-ms_v_out[];
-
 struct Task {
   uint baseID;
   uint8_t deltaIDs[EXT_TASK_WORK_GROUP_INVOCATIONS];
@@ -53,15 +44,10 @@ uint laneID = gl_LocalInvocationID.x;
 
 #include "KineticVoronoiRenderingConstants.glsl"
 
-void SetUpTriangleVertex(uint vertex_index, in vec3 vertex_normal, in SegmentMeshletVertex segment_meshlet_vertex) {
+void SetUpTriangleVertex(uint vertex_index, in SegmentMeshletVertex segment_meshlet_vertex) {
   mat4 transform = EE_POINT_LIGHTS[EE_CAMERA_INDEX].light_space_matrix[EE_INSTANCE_INDEX];
 
   vec3 pos = segment_meshlet_vertex.x - fracture_distance * segment_meshlet_vertex.shift;
-  ms_v_out[vertex_index].FragPos = pos;
-
-  ms_v_out[vertex_index].Normal = vertex_normal;
-  ms_v_out[vertex_index].Tangent = vec3(0.0, 1.0, 0.0);     // TODO
-  ms_v_out[vertex_index].Color = vec4(1.0, 1.0, 1.0, 1.0);  // TODO
   gl_MeshVerticesEXT[vertex_index].gl_Position = transform * vec4(pos, 1.0);
 }
 
@@ -79,8 +65,7 @@ void main() {
       for (int j = 0; j < 3; j++) {
         uint global_vertex_index = tri.vertex_indices[j];
         SegmentMeshletVertex segment_meshlet_vertex = segment_meshlet_vertices[global_vertex_index];
-        vec3 normal = vec3(1, 0, 0);
-        SetUpTriangleVertex(j, normal, segment_meshlet_vertex);
+        SetUpTriangleVertex(j, segment_meshlet_vertex);
       }
     }
   }

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/KineticVoronoiMeshing/SegmentMeshlet/SpotLightShadowMap.mesh
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/KineticVoronoiMeshing/SegmentMeshlet/SpotLightShadowMap.mesh
@@ -27,15 +27,6 @@ layout(max_vertices = MAX_VERTEX_COUNT, max_primitives = MAX_PRIMITIVE_COUNT) ou
 const uint TETRAHEDRON_VERTEX_ITERATIONS = ((MAX_VERTEX_COUNT + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
 const uint TETRAHEDRON_PRIMITIVE_ITERATIONS = ((MAX_PRIMITIVE_COUNT + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE);
 
-layout(location = 0) out MS_V_OUT {
-  vec3 FragPos;
-  vec3 Normal;
-  vec3 Tangent;
-  vec2 TexCoord;
-  vec4 Color;
-}
-ms_v_out[];
-
 struct Task {
   uint baseID;
   uint8_t deltaIDs[EXT_TASK_WORK_GROUP_INVOCATIONS];
@@ -53,15 +44,10 @@ uint laneID = gl_LocalInvocationID.x;
 
 #include "KineticVoronoiRenderingConstants.glsl"
 
-void SetUpTriangleVertex(uint vertex_index, in vec3 vertex_normal, in SegmentMeshletVertex segment_meshlet_vertex) {
+void SetUpTriangleVertex(uint vertex_index, in SegmentMeshletVertex segment_meshlet_vertex) {
   mat4 transform = EE_SPOT_LIGHTS[EE_CAMERA_INDEX].light_space_matrix;
 
   vec3 pos = segment_meshlet_vertex.x - fracture_distance * segment_meshlet_vertex.shift;
-  ms_v_out[vertex_index].FragPos = pos;
-
-  ms_v_out[vertex_index].Normal = vertex_normal;
-  ms_v_out[vertex_index].Tangent = vec3(0.0, 1.0, 0.0);     // TODO
-  ms_v_out[vertex_index].Color = vec4(1.0, 1.0, 1.0, 1.0);  // TODO
   gl_MeshVerticesEXT[vertex_index].gl_Position = transform * vec4(pos, 1.0);
 }
 
@@ -79,8 +65,7 @@ void main() {
       for (int j = 0; j < 3; j++) {
         uint global_vertex_index = tri.vertex_indices[j];
         SegmentMeshletVertex segment_meshlet_vertex = segment_meshlet_vertices[global_vertex_index];
-        vec3 normal = vec3(1, 0, 0);
-        SetUpTriangleVertex(j, normal, segment_meshlet_vertex);
+        SetUpTriangleVertex(j, segment_meshlet_vertex);
       }
     }
   }

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/SegmentPairs/Rendering.mesh
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Rendering/SegmentPairs/Rendering.mesh
@@ -27,6 +27,7 @@ layout(location = 0) out MS_V_OUT {
   vec3 frag_pos;
   vec3 normal;
   vec3 tangent;
+  vec2 tex_coord;
   vec4 color;
 }
 ms_v_out[];
@@ -146,13 +147,14 @@ void main() {
   [[unroll]]
   for (uint i = 0; i < uint(segment_pair_VERTEX_ITERATIONS); ++i) {
     uint vertex_index = laneID + i * WORKGROUP_SIZE;
-    if (vertex_index > segment_pair_VERTICES_SIZE)
+    if (vertex_index >= segment_pair_VERTICES_SIZE)
       break;
     vec3 vertex_position = positions[vertex_index];
 
     ms_v_out[vertex_index].frag_pos = vec4(instance_matrix * vec4(vertex_position, 1.0)).xyz;
     ms_v_out[vertex_index].normal = vec3(0, 1, 0);
     ms_v_out[vertex_index].tangent = vec3(0, 0, 1);
+    ms_v_out[vertex_index].tex_coord = vertex_position.xy + vec2(0.5);
     ms_v_out[vertex_index].color = color;
     gl_MeshVerticesEXT[vertex_index].gl_Position = transform * vec4(vertex_position, 1.0);
   }
@@ -160,7 +162,7 @@ void main() {
   [[unroll]]
   for (uint i = 0; i < uint(segment_pair_PRIMITIVE_ITERATIONS); ++i) {
     uint triangle_index = laneID + i * WORKGROUP_SIZE;
-    if (triangle_index <= segment_pair_TRIANGLE_SIZE) {
+    if (triangle_index < segment_pair_TRIANGLE_SIZE) {
       gl_PrimitiveTriangleIndicesEXT[triangle_index] = triangles[triangle_index];
     }
   }

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Visualization/SegmentPairs.mesh
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/Visualization/SegmentPairs.mesh
@@ -151,7 +151,7 @@ void main() {
   [[unroll]]
   for (uint i = 0; i < uint(segment_pair_VERTEX_ITERATIONS); ++i) {
     uint vertex_index = laneID + i * WORKGROUP_SIZE;
-    if (vertex_index > segment_pair_VERTICES_SIZE)
+    if (vertex_index >= segment_pair_VERTICES_SIZE)
       break;
     vec3 vertex_position = positions[vertex_index];
 
@@ -165,7 +165,7 @@ void main() {
   [[unroll]]
   for (uint i = 0; i < uint(segment_pair_PRIMITIVE_ITERATIONS); ++i) {
     uint triangle_index = laneID + i * WORKGROUP_SIZE;
-    if (triangle_index <= segment_pair_TRIANGLE_SIZE) {
+    if (triangle_index < segment_pair_TRIANGLE_SIZE) {
       gl_PrimitiveTriangleIndicesEXT[triangle_index] = triangles[triangle_index];
     }
   }

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Task/DynamicStrands/Rendering/SegmentPairs.task
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Task/DynamicStrands/Rendering/SegmentPairs.task
@@ -60,11 +60,11 @@ void main() {
     uint segment_pair_index_local = laneID + i * WORKGROUP_SIZE;
     uint segment_pair_index_global = baseID + segment_pair_index_local;
 
-    SegmentPair segment_pair = segment_pairs[segment_pair_index_global];
-    Segment segment0 = segments[segment_pair.segment0_handle];
-    Segment segment1 = segments[segment_pair.segment1_handle];
-    bool render = !(segment_pair_index_global >= segment_pairs_size) &&
-                  (segment_pair.connectivity_integrity > 0.0f || segment_pair.bend_twist_bundle_integrity > 0.0f);
+    bool render = segment_pair_index_global < segment_pairs_size;
+    if (render) {
+      SegmentPair segment_pair = segment_pairs[segment_pair_index_global];
+      render = segment_pair.connectivity_integrity > 0.0f || segment_pair.bend_twist_bundle_integrity > 0.0f;
+    }
 
     uvec4 vote_segment_pairs = subgroupBallot(render);
     uint num_segment_pairs = subgroupBallotBitCount(vote_segment_pairs);

--- a/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Task/DynamicStrands/Visualization/SegmentPairs.task
+++ b/EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Task/DynamicStrands/Visualization/SegmentPairs.task
@@ -56,11 +56,11 @@ void main() {
     uint segment_pair_index_local = laneID + i * WORKGROUP_SIZE;
     uint segment_pair_index_global = baseID + segment_pair_index_local;
 
-    SegmentPair segment_pair = segment_pairs[segment_pair_index_global];
-    Segment segment0 = segments[segment_pair.segment0_handle];
-    Segment segment1 = segments[segment_pair.segment1_handle];
-    bool render = !(segment_pair_index_global >= segment_pairs_size) &&
-                  (segment_pair.connectivity_integrity > 0.0f || segment_pair.bend_twist_bundle_integrity > 0.0f);
+    bool render = segment_pair_index_global < segment_pairs_size;
+    if (render) {
+      SegmentPair segment_pair = segment_pairs[segment_pair_index_global];
+      render = segment_pair.connectivity_integrity > 0.0f || segment_pair.bend_twist_bundle_integrity > 0.0f;
+    }
 
     uvec4 vote_segment_pairs = subgroupBallot(render);
     uint num_segment_pairs = subgroupBallotBitCount(vote_segment_pairs);

--- a/EvoEngine_Packages/EcoSysLab/include/EcoSysLabLayer.hpp
+++ b/EvoEngine_Packages/EcoSysLab/include/EcoSysLabLayer.hpp
@@ -19,6 +19,8 @@ using namespace evo_engine;
  */
 class EcoSysLabLayer : public ILayer {
  public:
+  void OnDestroy() override;
+
   /**
    * @brief Enables drag and drop functionality for the visualization camera.
    */

--- a/EvoEngine_Packages/EcoSysLab/include/Physics/DynamicStrands/DsOperators.hpp
+++ b/EvoEngine_Packages/EcoSysLab/include/Physics/DynamicStrands/DsOperators.hpp
@@ -593,7 +593,9 @@ class DsFungusInjection : public IDsOperator {
       find_closest_pipeline{};  ///< Compute pipeline for minimum distance calculations.
   inline static std::shared_ptr<ComputePipeline> inject_pipeline{};  ///< Compute pipeline for fungus injection.
   inline static std::shared_ptr<DescriptorSet>
-      min_distance_descriptor_set{};          ///< Descriptor set for minimum distance calculations.
+      min_distance_descriptor_set{};  ///< Descriptor set for minimum distance calculations.
+  inline static std::shared_ptr<Buffer> min_distance_buffer{};
+  inline static std::shared_ptr<DescriptorSetLayout> min_distance_layout{};
   FungusInjectionPushConstant push_constant;  ///< Push constant controlling the fungus injection operation.
  public:
   glm::vec3 target_position;  ///< Target position for fungus injection.
@@ -601,6 +603,11 @@ class DsFungusInjection : public IDsOperator {
    * @brief Constructor initializing default values.
    */
   DsFungusInjection();
+
+  /**
+   * @brief Releases static GPU resources before the EcoSysLab package unloads.
+   */
+  static void ReleaseStaticGpuResources();
 
   /**
    * @brief Updates the fungus injection parameters.

--- a/EvoEngine_Packages/EcoSysLab/include/Physics/DynamicStrands/DsPhysics.hpp
+++ b/EvoEngine_Packages/EcoSysLab/include/Physics/DynamicStrands/DsPhysics.hpp
@@ -28,11 +28,13 @@ class DsFungus {
     float HL_threshold = 0.4f;
     uint32_t treespace = 1;
     float padding1 = 0.0f;
-    glm::mat4 matrixAw4;
-    glm::mat4 matrixAb4;
-    glm::mat4 matrixAc4;
-    glm::mat4 matrixAm4;
+    glm::vec4 matrixAw[3] = {};
+    glm::vec4 matrixAb[3] = {};
+    glm::vec4 matrixAc[3] = {};
+    glm::vec4 matrixAm[3] = {};
   };
+  static_assert(sizeof(FungusDiffusionEdgePushConstant) == 224,
+                "Fungus diffusion edge push constants must stay packed as 32 scalar bytes plus 12 vec4 columns.");
 
   /**
    * @struct FungusDiffusionNodePushConstant

--- a/EvoEngine_Packages/EcoSysLab/include/Physics/DynamicStrands/DynamicStrands.hpp
+++ b/EvoEngine_Packages/EcoSysLab/include/Physics/DynamicStrands/DynamicStrands.hpp
@@ -520,13 +520,16 @@ class DynamicStrands {
   void RenderCompute() const;
   static void BuildFoliageRenderingPipelines();
   static void BuildSegmentPairsRenderingPipeline();
+  static void ReleaseStaticGpuResources();
 
   inline static std::shared_ptr<GraphicsPipeline> foliage_point_light_render_pipeline{};
   inline static std::shared_ptr<GraphicsPipeline> foliage_spot_light_render_pipeline{};
   inline static std::shared_ptr<GraphicsPipeline> foliage_directional_light_render_pipeline{};
   inline static std::shared_ptr<GraphicsPipeline> foliage_render_pipeline{};
 
+  inline static std::shared_ptr<GraphicsPipeline> segment_visualization_render_pipeline{};
   inline static std::shared_ptr<GraphicsPipeline> segment_pairs_visualization_render_pipeline{};
+  inline static std::shared_ptr<GraphicsPipeline> foliage_visualization_render_pipeline{};
 
   DsMaterials& materials;
 

--- a/EvoEngine_Packages/EcoSysLab/src/DsOperators.cpp
+++ b/EvoEngine_Packages/EcoSysLab/src/DsOperators.cpp
@@ -725,9 +725,6 @@ void DsStopAll::Execute(const DynamicStrands::PhysicsParameters& physics_paramet
 }
 
 DsFungusInjection::DsFungusInjection() {
-  static std::shared_ptr<Buffer> min_distance_buffer{};
-  static std::shared_ptr<DescriptorSetLayout> min_distance_layout{};
-
   if (!min_distance_layout) {
     min_distance_layout = std::make_shared<DescriptorSetLayout>();
     min_distance_layout->PushDescriptorBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_SHADER_STAGE_COMPUTE_BIT, 0);
@@ -735,8 +732,7 @@ DsFungusInjection::DsFungusInjection() {
   }
 
   if (!min_dist_reset_pipeline) {
-    static std::shared_ptr<Shader> reset_shader{};
-    reset_shader = std::make_shared<Shader>();
+    const auto reset_shader = std::make_shared<Shader>();
     reset_shader->TryCompile(
         ShaderType::Compute, Platform::GetShaderGlobalDefines(),
         std::filesystem::path("./EcoSysLabResources") / "Shaders/Compute/DynamicStrands/Operators/MinDistReset.comp");
@@ -748,8 +744,7 @@ DsFungusInjection::DsFungusInjection() {
   }
 
   if (!find_closest_pipeline) {
-    static std::shared_ptr<Shader> find_closest_shader{};
-    find_closest_shader = std::make_shared<Shader>();
+    const auto find_closest_shader = std::make_shared<Shader>();
     find_closest_shader->TryCompile(ShaderType::Compute, Platform::GetShaderGlobalDefines(),
                                     std::filesystem::path("./EcoSysLabResources") /
                                         "Shaders/Compute/DynamicStrands/Operators/FungusFindClosest.comp");
@@ -766,8 +761,7 @@ DsFungusInjection::DsFungusInjection() {
   }
 
   if (!inject_pipeline) {
-    static std::shared_ptr<Shader> injection_shader{};
-    injection_shader = std::make_shared<Shader>();
+    const auto injection_shader = std::make_shared<Shader>();
     injection_shader->TryCompile(ShaderType::Compute, Platform::GetShaderGlobalDefines(),
                                  std::filesystem::path("./EcoSysLabResources") /
                                      "Shaders/Compute/DynamicStrands/Operators/FungusInjection.comp");
@@ -808,6 +802,15 @@ DsFungusInjection::DsFungusInjection() {
   min_distance_buffer->Resize(sizeof(GpuMinDistance));
   min_distance_descriptor_set->UpdateBufferDescriptorBinding(0, min_distance_buffer);
   min_distance_buffer->SetDebugName("Min distance buffer");
+}
+
+void DsFungusInjection::ReleaseStaticGpuResources() {
+  min_distance_descriptor_set.reset();
+  inject_pipeline.reset();
+  find_closest_pipeline.reset();
+  min_dist_reset_pipeline.reset();
+  min_distance_buffer.reset();
+  min_distance_layout.reset();
 }
 
 void DsFungusInjection::Update(const glm::vec2& point, const glm::vec2& screen_size, float point_size,

--- a/EvoEngine_Packages/EcoSysLab/src/DsPhysics.cpp
+++ b/EvoEngine_Packages/EcoSysLab/src/DsPhysics.cpp
@@ -46,6 +46,14 @@ bool DsFungus::DrawGui(const std::shared_ptr<EditorLayer>& editor_layer) {
   return changed;
 }
 
+namespace {
+void PackMat3Columns(glm::vec4 (&target)[3], const glm::mat3& source) {
+  target[0] = glm::vec4(source[0], 0.0f);
+  target[1] = glm::vec4(source[1], 0.0f);
+  target[2] = glm::vec4(source[2], 0.0f);
+}
+}  // namespace
+
 void DsFungus::Execute(const DynamicStrands::PhysicsParameters& physics_parameters,
                        const DynamicStrands& target_dynamic_strands) {
   const auto current_frame_index = Platform::GetCurrentFrameIndex();
@@ -60,10 +68,10 @@ void DsFungus::Execute(const DynamicStrands::PhysicsParameters& physics_paramete
   edge_push_constant.HC_threshold = physics_parameters.HC_threshold;
   edge_push_constant.HL_threshold = physics_parameters.HL_threshold;
   edge_push_constant.treespace = physics_parameters.treespace;
-  edge_push_constant.matrixAw4 = glm::mat4(physics_parameters.matrixAw);
-  edge_push_constant.matrixAb4 = glm::mat4(physics_parameters.matrixAb);
-  edge_push_constant.matrixAc4 = glm::mat4(physics_parameters.matrixAc);
-  edge_push_constant.matrixAm4 = glm::mat4(physics_parameters.matrixAm);
+  PackMat3Columns(edge_push_constant.matrixAw, physics_parameters.matrixAw);
+  PackMat3Columns(edge_push_constant.matrixAb, physics_parameters.matrixAb);
+  PackMat3Columns(edge_push_constant.matrixAc, physics_parameters.matrixAc);
+  PackMat3Columns(edge_push_constant.matrixAm, physics_parameters.matrixAm);
 
   // Then, update fungal properties on nodes (segments)
   FungusDiffusionNodePushConstant node_push_constant;

--- a/EvoEngine_Packages/EcoSysLab/src/DynamicStrands.cpp
+++ b/EvoEngine_Packages/EcoSysLab/src/DynamicStrands.cpp
@@ -15,6 +15,20 @@ inline glm::vec3 cgal_to_glm(const Point_CGAL& p) {
   return {p.x(), p.y(), p.z()};
 }
 #endif
+
+void DynamicStrands::ReleaseStaticGpuResources() {
+  foliage_visualization_render_pipeline.reset();
+  segment_pairs_visualization_render_pipeline.reset();
+  segment_visualization_render_pipeline.reset();
+
+  foliage_render_pipeline.reset();
+  foliage_directional_light_render_pipeline.reset();
+  foliage_spot_light_render_pipeline.reset();
+  foliage_point_light_render_pipeline.reset();
+
+  strands_layout.reset();
+}
+
 void DynamicStrands::Physics(const PhysicsParameters& physics_parameters,
                              const std::function<void()>& pre_step_action) {
   if (pre_step)
@@ -547,19 +561,17 @@ bool DynamicStrands::PhysicsParameters::DrawGui(const std::shared_ptr<EditorLaye
 }
 
 void DynamicStrands::UpdateBindings() const {
-  if (segments.empty())
-    return;
   const auto current_frame_index = Platform::GetCurrentFrameIndex();
+  const auto& descriptor_set = strands_descriptor_sets[current_frame_index];
 
-  strands_descriptor_sets[current_frame_index]->UpdateBufferDescriptorBinding(0, device_strands_buffer, 0);
-  strands_descriptor_sets[current_frame_index]->UpdateBufferDescriptorBinding(1, device_nodes_buffer, 0);
-  strands_descriptor_sets[current_frame_index]->UpdateBufferDescriptorBinding(2, device_segments_buffer, 0);
-  strands_descriptor_sets[current_frame_index]->UpdateBufferDescriptorBinding(3, device_segment_pairs_buffer, 0);
-  strands_descriptor_sets[current_frame_index]->UpdateBufferDescriptorBinding(4, device_segment_data_list_buffer, 0);
-  strands_descriptor_sets[current_frame_index]->UpdateBufferDescriptorBinding(5, device_hashed_grid_elements_buffer, 0);
-  strands_descriptor_sets[current_frame_index]->UpdateBufferDescriptorBinding(6, device_hashed_grid_cell_starts_buffer,
-                                                                              0);
-  strands_descriptor_sets[current_frame_index]->UpdateBufferDescriptorBinding(7, device_foliage_buffer, 0);
+  descriptor_set->UpdateBufferDescriptorBinding(0, device_strands_buffer, 0);
+  descriptor_set->UpdateBufferDescriptorBinding(1, device_nodes_buffer, 0);
+  descriptor_set->UpdateBufferDescriptorBinding(2, device_segments_buffer, 0);
+  descriptor_set->UpdateBufferDescriptorBinding(3, device_segment_pairs_buffer, 0);
+  descriptor_set->UpdateBufferDescriptorBinding(4, device_segment_data_list_buffer, 0);
+  descriptor_set->UpdateBufferDescriptorBinding(5, device_hashed_grid_elements_buffer, 0);
+  descriptor_set->UpdateBufferDescriptorBinding(6, device_hashed_grid_cell_starts_buffer, 0);
+  descriptor_set->UpdateBufferDescriptorBinding(7, device_foliage_buffer, 0);
 
   meshing->UpdateBindings();
   for (const auto& c : constraints) {

--- a/EvoEngine_Packages/EcoSysLab/src/DynamicStrandsVisualization.cpp
+++ b/EvoEngine_Packages/EcoSysLab/src/DynamicStrandsVisualization.cpp
@@ -17,7 +17,6 @@ void DynamicStrands::Visualize(const std::shared_ptr<Camera>& target_camera,
   }
   const auto current_frame_index = Platform::GetCurrentFrameIndex();
 
-  static std::shared_ptr<GraphicsPipeline> segment_render_pipeline{};
   struct SegmentRenderPushConstant {
     glm::vec4 min_color = glm::vec4(0.2f);
     glm::vec4 max_color = glm::vec4(1.f);
@@ -30,46 +29,42 @@ void DynamicStrands::Visualize(const std::shared_ptr<Camera>& target_camera,
     float length_multiplier = 1.0f;
   };
 
-  if (!segment_render_pipeline) {
-    static std::shared_ptr<Shader> task_shader{};
-    static std::shared_ptr<Shader> mesh_shader{};
-    static std::shared_ptr<Shader> frag_shader{};
+  if (!segment_visualization_render_pipeline) {
     // Load shader
-    task_shader = std::make_shared<Shader>();
+    const auto task_shader = std::make_shared<Shader>();
     task_shader->TryCompile(ShaderType::Task, Platform::GetShaderGlobalDefines(),
                             std::filesystem::path("./EcoSysLabResources") /
                                 "Shaders/Graphics/Task/DynamicStrands/Visualization/Segments.task");
-    mesh_shader = std::make_shared<Shader>();
+    const auto mesh_shader = std::make_shared<Shader>();
     mesh_shader->TryCompile(ShaderType::Mesh, Platform::GetShaderGlobalDefines(),
                             std::filesystem::path("./EcoSysLabResources") /
                                 "Shaders/Graphics/Mesh/DynamicStrands/Visualization/Segments.mesh");
-    frag_shader = std::make_shared<Shader>();
+    const auto frag_shader = std::make_shared<Shader>();
     frag_shader->TryCompile(
         ShaderType::Fragment, Platform::GetShaderGlobalDefines(),
         std::filesystem::path("./EcoSysLabResources") / "Shaders/Graphics/Fragment/DynamicStrands/Visualization.frag");
     // Descriptor set layout
-    segment_render_pipeline = std::make_shared<GraphicsPipeline>();
-    segment_render_pipeline->task_shader = task_shader;
-    segment_render_pipeline->mesh_shader = mesh_shader;
+    segment_visualization_render_pipeline = std::make_shared<GraphicsPipeline>();
+    segment_visualization_render_pipeline->task_shader = task_shader;
+    segment_visualization_render_pipeline->mesh_shader = mesh_shader;
 
-    segment_render_pipeline->fragment_shader = frag_shader;
-    segment_render_pipeline->geometry_type = GeometryType::Mesh;
+    segment_visualization_render_pipeline->fragment_shader = frag_shader;
+    segment_visualization_render_pipeline->geometry_type = GeometryType::Mesh;
 
-    segment_render_pipeline->descriptor_set_layouts.emplace_back(
+    segment_visualization_render_pipeline->descriptor_set_layouts.emplace_back(
         ApplicationContext::Get().GetLayer<RenderLayer>()->GetPerFrameDescriptorSetLayout());
-    segment_render_pipeline->descriptor_set_layouts.emplace_back(strands_layout);
-    segment_render_pipeline->depth_attachment_format = Platform::Constants::render_texture_depth;
-    segment_render_pipeline->stencil_attachment_format = VK_FORMAT_UNDEFINED;
-    segment_render_pipeline->color_attachment_formats = {1, Platform::Constants::render_texture_color};
+    segment_visualization_render_pipeline->descriptor_set_layouts.emplace_back(strands_layout);
+    segment_visualization_render_pipeline->depth_attachment_format = Platform::Constants::render_texture_depth;
+    segment_visualization_render_pipeline->stencil_attachment_format = VK_FORMAT_UNDEFINED;
+    segment_visualization_render_pipeline->color_attachment_formats = {1, Platform::Constants::render_texture_color};
 
-    auto& push_constant_range = segment_render_pipeline->push_constant_ranges.emplace_back();
+    auto& push_constant_range = segment_visualization_render_pipeline->push_constant_ranges.emplace_back();
     push_constant_range.size = sizeof(SegmentRenderPushConstant);
     push_constant_range.offset = 0;
     push_constant_range.stageFlags = VK_SHADER_STAGE_ALL;
 
-    segment_render_pipeline->Initialize();
+    segment_visualization_render_pipeline->Initialize();
   }
-  static std::shared_ptr<GraphicsPipeline> segment_pair_render_pipeline{};
   struct SegmentPairRenderPushConstant {
     glm::vec4 min_color = glm::vec4(0.2f);
     glm::vec4 max_color = glm::vec4(1.f);
@@ -81,47 +76,44 @@ void DynamicStrands::Visualize(const std::shared_ptr<Camera>& target_camera,
     float factor = 1.0f;
   };
 
-  if (!segment_pair_render_pipeline) {
-    static std::shared_ptr<Shader> task_shader{};
-    static std::shared_ptr<Shader> mesh_shader{};
-    static std::shared_ptr<Shader> frag_shader{};
+  if (!segment_pairs_visualization_render_pipeline) {
     // Load shader
-    task_shader = std::make_shared<Shader>();
+    const auto task_shader = std::make_shared<Shader>();
     task_shader->TryCompile(ShaderType::Task, Platform::GetShaderGlobalDefines(),
                             std::filesystem::path("./EcoSysLabResources") /
                                 "Shaders/Graphics/Task/DynamicStrands/Visualization/SegmentPairs.task");
-    mesh_shader = std::make_shared<Shader>();
+    const auto mesh_shader = std::make_shared<Shader>();
     mesh_shader->TryCompile(ShaderType::Mesh, Platform::GetShaderGlobalDefines(),
                             std::filesystem::path("./EcoSysLabResources") /
                                 "Shaders/Graphics/Mesh/DynamicStrands/Visualization/SegmentPairs.mesh");
-    frag_shader = std::make_shared<Shader>();
+    const auto frag_shader = std::make_shared<Shader>();
     frag_shader->TryCompile(
         ShaderType::Fragment, Platform::GetShaderGlobalDefines(),
         std::filesystem::path("./EcoSysLabResources") / "Shaders/Graphics/Fragment/DynamicStrands/Visualization.frag");
     // Descriptor set layout
-    segment_pair_render_pipeline = std::make_shared<GraphicsPipeline>();
-    segment_pair_render_pipeline->task_shader = task_shader;
-    segment_pair_render_pipeline->mesh_shader = mesh_shader;
+    segment_pairs_visualization_render_pipeline = std::make_shared<GraphicsPipeline>();
+    segment_pairs_visualization_render_pipeline->task_shader = task_shader;
+    segment_pairs_visualization_render_pipeline->mesh_shader = mesh_shader;
 
-    segment_pair_render_pipeline->fragment_shader = frag_shader;
-    segment_pair_render_pipeline->geometry_type = GeometryType::Mesh;
+    segment_pairs_visualization_render_pipeline->fragment_shader = frag_shader;
+    segment_pairs_visualization_render_pipeline->geometry_type = GeometryType::Mesh;
 
-    segment_pair_render_pipeline->descriptor_set_layouts.emplace_back(
+    segment_pairs_visualization_render_pipeline->descriptor_set_layouts.emplace_back(
         ApplicationContext::Get().GetLayer<RenderLayer>()->GetPerFrameDescriptorSetLayout());
-    segment_pair_render_pipeline->descriptor_set_layouts.emplace_back(strands_layout);
-    segment_pair_render_pipeline->depth_attachment_format = Platform::Constants::render_texture_depth;
-    segment_pair_render_pipeline->stencil_attachment_format = VK_FORMAT_UNDEFINED;
-    segment_pair_render_pipeline->color_attachment_formats = {1, Platform::Constants::render_texture_color};
+    segment_pairs_visualization_render_pipeline->descriptor_set_layouts.emplace_back(strands_layout);
+    segment_pairs_visualization_render_pipeline->depth_attachment_format = Platform::Constants::render_texture_depth;
+    segment_pairs_visualization_render_pipeline->stencil_attachment_format = VK_FORMAT_UNDEFINED;
+    segment_pairs_visualization_render_pipeline->color_attachment_formats = {1,
+                                                                             Platform::Constants::render_texture_color};
 
-    auto& push_constant_range = segment_pair_render_pipeline->push_constant_ranges.emplace_back();
+    auto& push_constant_range = segment_pairs_visualization_render_pipeline->push_constant_ranges.emplace_back();
     push_constant_range.size = sizeof(SegmentPairRenderPushConstant);
     push_constant_range.offset = 0;
     push_constant_range.stageFlags = VK_SHADER_STAGE_ALL;
 
-    segment_pair_render_pipeline->Initialize();
+    segment_pairs_visualization_render_pipeline->Initialize();
   }
 
-  static std::shared_ptr<GraphicsPipeline> foliage_render_pipeline{};
   struct FoliageRenderPushConstant {
     glm::vec4 min_color = glm::vec4(0.2f);
     glm::vec4 max_color = glm::vec4(1.f);
@@ -131,44 +123,41 @@ void DynamicStrands::Visualize(const std::shared_ptr<Camera>& target_camera,
     uint32_t render_mode = 0;
   };
 
-  if (!foliage_render_pipeline) {
-    static std::shared_ptr<Shader> task_shader{};
-    static std::shared_ptr<Shader> mesh_shader{};
-    static std::shared_ptr<Shader> frag_shader{};
+  if (!foliage_visualization_render_pipeline) {
     // Load shader
-    task_shader = std::make_shared<Shader>();
+    const auto task_shader = std::make_shared<Shader>();
     task_shader->TryCompile(ShaderType::Task, Platform::GetShaderGlobalDefines(),
                             std::filesystem::path("./EcoSysLabResources") /
                                 "Shaders/Graphics/Task/DynamicStrands/Visualization/Foliage.task");
-    mesh_shader = std::make_shared<Shader>();
+    const auto mesh_shader = std::make_shared<Shader>();
     mesh_shader->TryCompile(ShaderType::Mesh, Platform::GetShaderGlobalDefines(),
                             std::filesystem::path("./EcoSysLabResources") /
                                 "Shaders/Graphics/Mesh/DynamicStrands/Visualization/Foliage.mesh");
-    frag_shader = std::make_shared<Shader>();
+    const auto frag_shader = std::make_shared<Shader>();
     frag_shader->TryCompile(
         ShaderType::Fragment, Platform::GetShaderGlobalDefines(),
         std::filesystem::path("./EcoSysLabResources") / "Shaders/Graphics/Fragment/DynamicStrands/Visualization.frag");
     // Descriptor set layout
-    foliage_render_pipeline = std::make_shared<GraphicsPipeline>();
-    foliage_render_pipeline->task_shader = task_shader;
-    foliage_render_pipeline->mesh_shader = mesh_shader;
+    foliage_visualization_render_pipeline = std::make_shared<GraphicsPipeline>();
+    foliage_visualization_render_pipeline->task_shader = task_shader;
+    foliage_visualization_render_pipeline->mesh_shader = mesh_shader;
 
-    foliage_render_pipeline->fragment_shader = frag_shader;
-    foliage_render_pipeline->geometry_type = GeometryType::Mesh;
+    foliage_visualization_render_pipeline->fragment_shader = frag_shader;
+    foliage_visualization_render_pipeline->geometry_type = GeometryType::Mesh;
 
-    foliage_render_pipeline->descriptor_set_layouts.emplace_back(
+    foliage_visualization_render_pipeline->descriptor_set_layouts.emplace_back(
         ApplicationContext::Get().GetLayer<RenderLayer>()->GetPerFrameDescriptorSetLayout());
-    foliage_render_pipeline->descriptor_set_layouts.emplace_back(strands_layout);
-    foliage_render_pipeline->depth_attachment_format = Platform::Constants::render_texture_depth;
-    foliage_render_pipeline->stencil_attachment_format = VK_FORMAT_UNDEFINED;
-    foliage_render_pipeline->color_attachment_formats = {1, Platform::Constants::render_texture_color};
+    foliage_visualization_render_pipeline->descriptor_set_layouts.emplace_back(strands_layout);
+    foliage_visualization_render_pipeline->depth_attachment_format = Platform::Constants::render_texture_depth;
+    foliage_visualization_render_pipeline->stencil_attachment_format = VK_FORMAT_UNDEFINED;
+    foliage_visualization_render_pipeline->color_attachment_formats = {1, Platform::Constants::render_texture_color};
 
-    auto& push_constant_range = foliage_render_pipeline->push_constant_ranges.emplace_back();
+    auto& push_constant_range = foliage_visualization_render_pipeline->push_constant_ranges.emplace_back();
     push_constant_range.size = sizeof(FoliageRenderPushConstant);
     push_constant_range.offset = 0;
     push_constant_range.stageFlags = VK_SHADER_STAGE_ALL;
 
-    foliage_render_pipeline->Initialize();
+    foliage_visualization_render_pipeline->Initialize();
   }
 
   const uint32_t task_work_group_invocations =
@@ -287,65 +276,65 @@ void DynamicStrands::Visualize(const std::shared_ptr<Camera>& target_camera,
     // GBuffer)
 
     if (visualization_parameters.render_segment_pairs) {
-      segment_pair_render_pipeline->states.ResetAllStates(1);
-      segment_pair_render_pipeline->states.view_port = viewport;
-      segment_pair_render_pipeline->states.scissor = scissor;
-      segment_pair_render_pipeline->states.polygon_mode = VK_POLYGON_MODE_FILL;
-      segment_pair_render_pipeline->states.color_blend_attachment_states[0].blendEnable = true;
+      segment_pairs_visualization_render_pipeline->states.ResetAllStates(1);
+      segment_pairs_visualization_render_pipeline->states.view_port = viewport;
+      segment_pairs_visualization_render_pipeline->states.scissor = scissor;
+      segment_pairs_visualization_render_pipeline->states.polygon_mode = VK_POLYGON_MODE_FILL;
+      segment_pairs_visualization_render_pipeline->states.color_blend_attachment_states[0].blendEnable = true;
 
-      segment_pair_render_pipeline->states.ApplyAllStates(vk_command_buffer);
+      segment_pairs_visualization_render_pipeline->states.ApplyAllStates(vk_command_buffer);
       target_camera->GetRenderTexture()->Render(
           vk_command_buffer, VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE, [&] {
-            segment_pair_render_pipeline->Bind(vk_command_buffer);
-            segment_pair_render_pipeline->BindDescriptorSet(
+            segment_pairs_visualization_render_pipeline->Bind(vk_command_buffer);
+            segment_pairs_visualization_render_pipeline->BindDescriptorSet(
                 vk_command_buffer, 0, RenderLayer::GetPerFrameDescriptorSet()->GetVkDescriptorSet());
-            segment_pair_render_pipeline->BindDescriptorSet(
+            segment_pairs_visualization_render_pipeline->BindDescriptorSet(
                 vk_command_buffer, 1, strands_descriptor_sets[current_frame_index]->GetVkDescriptorSet());
-            segment_pair_render_pipeline->PushConstant(vk_command_buffer, 0, segment_pair_push_constant);
+            segment_pairs_visualization_render_pipeline->PushConstant(vk_command_buffer, 0, segment_pair_push_constant);
             const uint32_t count = Platform::DivUp(segment_pairs.size(), task_work_group_invocations);
-            segment_pair_render_pipeline->DrawMeshTasks(vk_command_buffer, count, 1, 1);
+            segment_pairs_visualization_render_pipeline->DrawMeshTasks(vk_command_buffer, count, 1, 1);
           });
     }
 
     if (visualization_parameters.render_segments) {
-      segment_render_pipeline->states.ResetAllStates(1);
-      segment_render_pipeline->states.view_port = viewport;
-      segment_render_pipeline->states.scissor = scissor;
-      segment_render_pipeline->states.polygon_mode = VK_POLYGON_MODE_FILL;
-      segment_render_pipeline->states.color_blend_attachment_states[0].blendEnable = true;
+      segment_visualization_render_pipeline->states.ResetAllStates(1);
+      segment_visualization_render_pipeline->states.view_port = viewport;
+      segment_visualization_render_pipeline->states.scissor = scissor;
+      segment_visualization_render_pipeline->states.polygon_mode = VK_POLYGON_MODE_FILL;
+      segment_visualization_render_pipeline->states.color_blend_attachment_states[0].blendEnable = true;
 
-      segment_render_pipeline->states.ApplyAllStates(vk_command_buffer);
+      segment_visualization_render_pipeline->states.ApplyAllStates(vk_command_buffer);
       target_camera->GetRenderTexture()->Render(
           vk_command_buffer, VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE, [&] {
-            segment_render_pipeline->Bind(vk_command_buffer);
-            segment_render_pipeline->BindDescriptorSet(vk_command_buffer, 0,
-                                                       RenderLayer::GetPerFrameDescriptorSet()->GetVkDescriptorSet());
-            segment_render_pipeline->BindDescriptorSet(
+            segment_visualization_render_pipeline->Bind(vk_command_buffer);
+            segment_visualization_render_pipeline->BindDescriptorSet(
+                vk_command_buffer, 0, RenderLayer::GetPerFrameDescriptorSet()->GetVkDescriptorSet());
+            segment_visualization_render_pipeline->BindDescriptorSet(
                 vk_command_buffer, 1, strands_descriptor_sets[current_frame_index]->GetVkDescriptorSet());
-            segment_render_pipeline->PushConstant(vk_command_buffer, 0, segment_push_constant);
+            segment_visualization_render_pipeline->PushConstant(vk_command_buffer, 0, segment_push_constant);
             const uint32_t count = Platform::DivUp(segments.size(), task_work_group_invocations);
-            segment_render_pipeline->DrawMeshTasks(vk_command_buffer, count, 1, 1);
+            segment_visualization_render_pipeline->DrawMeshTasks(vk_command_buffer, count, 1, 1);
           });
     }
 
     if (visualization_parameters.render_foliage) {
-      foliage_render_pipeline->states.ResetAllStates(1);
-      foliage_render_pipeline->states.view_port = viewport;
-      foliage_render_pipeline->states.scissor = scissor;
-      foliage_render_pipeline->states.polygon_mode = VK_POLYGON_MODE_FILL;
-      foliage_render_pipeline->states.color_blend_attachment_states[0].blendEnable = true;
+      foliage_visualization_render_pipeline->states.ResetAllStates(1);
+      foliage_visualization_render_pipeline->states.view_port = viewport;
+      foliage_visualization_render_pipeline->states.scissor = scissor;
+      foliage_visualization_render_pipeline->states.polygon_mode = VK_POLYGON_MODE_FILL;
+      foliage_visualization_render_pipeline->states.color_blend_attachment_states[0].blendEnable = true;
 
-      foliage_render_pipeline->states.ApplyAllStates(vk_command_buffer);
+      foliage_visualization_render_pipeline->states.ApplyAllStates(vk_command_buffer);
       target_camera->GetRenderTexture()->Render(
           vk_command_buffer, VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE, [&] {
-            foliage_render_pipeline->Bind(vk_command_buffer);
-            foliage_render_pipeline->BindDescriptorSet(vk_command_buffer, 0,
-                                                       RenderLayer::GetPerFrameDescriptorSet()->GetVkDescriptorSet());
-            foliage_render_pipeline->BindDescriptorSet(
+            foliage_visualization_render_pipeline->Bind(vk_command_buffer);
+            foliage_visualization_render_pipeline->BindDescriptorSet(
+                vk_command_buffer, 0, RenderLayer::GetPerFrameDescriptorSet()->GetVkDescriptorSet());
+            foliage_visualization_render_pipeline->BindDescriptorSet(
                 vk_command_buffer, 1, strands_descriptor_sets[current_frame_index]->GetVkDescriptorSet());
-            foliage_render_pipeline->PushConstant(vk_command_buffer, 0, foliage_push_constant);
+            foliage_visualization_render_pipeline->PushConstant(vk_command_buffer, 0, foliage_push_constant);
             const uint32_t count = Platform::DivUp(foliage.size(), task_work_group_invocations);
-            foliage_render_pipeline->DrawMeshTasks(vk_command_buffer, count, 1, 1);
+            foliage_visualization_render_pipeline->DrawMeshTasks(vk_command_buffer, count, 1, 1);
           });
     }
   });

--- a/EvoEngine_Packages/EcoSysLab/src/EcoSysLabLayer.cpp
+++ b/EvoEngine_Packages/EcoSysLab/src/EcoSysLabLayer.cpp
@@ -20,6 +20,7 @@
 #include "Climate.hpp"
 #include "CubeVolume.hpp"
 #include "DsColliders.hpp"
+#include "DsOperators.hpp"
 #include "DynamicStrandsDemo.hpp"
 #include "DynamicStrandsVisualizationParameters.hpp"
 #include "DynamicTreeSkeleton.hpp"
@@ -39,6 +40,11 @@
 #include "TreeDescriptor.hpp"
 #include "TreeStructor.hpp"
 using namespace eco_sys_lab_package;
+
+void EcoSysLabLayer::OnDestroy() {
+  DsFungusInjection::ReleaseStaticGpuResources();
+  DynamicStrands::ReleaseStaticGpuResources();
+}
 
 namespace {
 template <typename T>

--- a/EvoEngine_Packages/EcoSysLab/src/EcoSysLabPackage.cpp
+++ b/EvoEngine_Packages/EcoSysLab/src/EcoSysLabPackage.cpp
@@ -11,6 +11,7 @@
 #include "Climate.hpp"
 #include "CubeVolume.hpp"
 #include "DsColliders.hpp"
+#include "DsOperators.hpp"
 #include "DynamicStrandsDemo.hpp"
 #include "DynamicTreeSkeleton.hpp"
 #include "DynamicTreeStrandGraph.hpp"
@@ -289,4 +290,5 @@ EVOENGINE_PACKAGE_EXPORT bool EvoEnginePackageLoad(PackageRegistrar*) {
 }
 
 EVOENGINE_PACKAGE_EXPORT void EvoEnginePackageUnload(PackageRegistrar*) {
+  DsFungusInjection::ReleaseStaticGpuResources();
 }

--- a/EvoEngine_SDK/Internals/DefaultResources/Shaders/Includes/GltfRasterMaterial.glsl
+++ b/EvoEngine_SDK/Internals/DefaultResources/Shaders/Includes/GltfRasterMaterial.glsl
@@ -543,6 +543,25 @@ GltfRasterMaterial EE_EVALUATE_GLTF_RASTER_SURFACE(uint material_index, vec2 tex
       material_index, EE_GLTF_MAKE_TEX_COORDS(tex_coord_0, tex_coord_1), vec4(1.0));
 }
 
+vec3 EE_GLTF_RASTER_REBASE_SPECULAR_F0(uint material_index, GltfRasterMaterial surface, vec3 base_color) {
+#if EE_GLTF_USE_SPECULAR_GLOSSINESS
+  GltfShadeMaterial material = EE_GLTF_MATERIALS[material_index];
+  if (material.pbr_model == EE_GLTF_PBR_MODEL_SPECULAR_GLOSSINESS) {
+    return surface.specular_f0;
+  }
+#endif
+  const float metallic = clamp(surface.metallic, 0.0, 1.0);
+  const vec3 rebased_base_color = max(base_color, vec3(0.0));
+  if (metallic >= 0.999999) {
+    return rebased_base_color;
+  }
+  const vec3 original_base_color = max(surface.base_color.rgb, vec3(0.0));
+  const vec3 dielectric_specular_f0 =
+      clamp((surface.specular_f0 - original_base_color * metallic) / max(1.0 - metallic, 0.000001), vec3(0.0),
+            vec3(1.0));
+  return mix(dielectric_specular_f0, rebased_base_color, metallic);
+}
+
 vec3 EE_GLTF_SAFE_NORMALIZE(vec3 value, vec3 fallback) {
   float length_squared = dot(value, value);
   return length_squared > 1e-12 ? value * inversesqrt(length_squared) : fallback;

--- a/EvoEngine_SDK/include/Layers/EditorLayer.hpp
+++ b/EvoEngine_SDK/include/Layers/EditorLayer.hpp
@@ -1149,7 +1149,7 @@ bool EditorLayer::DragAndDropButton(AssetRef& target, const std::string& name, c
       OpenAssetInspector(ptr ? ptr->GetHandle() : asset_handle);
     }
   } else {
-    ImGui::Button("none");
+    ImGui::Button((std::string("none##") + name).c_str());
   }
   ImGui::PopStyleColor(1);
   status_changed = Droppable<T>(target) || status_changed;
@@ -1166,7 +1166,7 @@ bool EditorLayer::DragAndDropButton(PrivateComponentRef& target, const std::stri
     const auto scene = ApplicationContext::Get().GetActiveScene();
     if (!scene->IsEntityValid(ptr->GetOwner())) {
       target.Clear();
-      ImGui::Button("none");
+      ImGui::Button((std::string("none##") + name).c_str());
       ImGui::PopStyleColor(1);
       return true;
     }
@@ -1179,7 +1179,7 @@ bool EditorLayer::DragAndDropButton(PrivateComponentRef& target, const std::stri
       selected_entity_ = ptr->GetOwner();
     }
   } else {
-    ImGui::Button("none");
+    ImGui::Button((std::string("none##") + name).c_str());
   }
   ImGui::PopStyleColor(1);
   status_changed = Droppable<T>(target) || status_changed;

--- a/EvoEngine_SDK/include/Rendering/PBR/EnvironmentalLighting.hpp
+++ b/EvoEngine_SDK/include/Rendering/PBR/EnvironmentalLighting.hpp
@@ -28,8 +28,8 @@ class EnvironmentalLighting final : public IAsset {
   static constexpr uint32_t kMaxDdgiVolumeCount = 8u;
   static constexpr int kMaxExactLocalReflectionProbePriority = 1 << 24;
   static constexpr float kDefaultEnvironmentLightingIntensity = 1.0f;
-  static constexpr float kDefaultDiffuseFallbackIntensity = 0.0f;
-  static constexpr float kDefaultSpecularFallbackIntensity = 0.0f;
+  static constexpr float kDefaultDiffuseFallbackIntensity = 1.0f;
+  static constexpr float kDefaultSpecularFallbackIntensity = 1.0f;
   static constexpr float kSpecularVisibilityGrazingOcclusionCap = 0.04f;
   static constexpr float kSpecularVisibilityFullTrustStart = 0.8f;
 

--- a/EvoEngine_SDK/include/Rendering/PBR/ResolvedEnvironmentalLighting.hpp
+++ b/EvoEngine_SDK/include/Rendering/PBR/ResolvedEnvironmentalLighting.hpp
@@ -34,8 +34,8 @@ struct ResolvedEnvironmentalLighting {
   static constexpr uint32_t kMaxLocalReflectionProbeCount = 32u;
   static constexpr uint32_t kMaxDdgiVolumeCount = 8u;
   static constexpr float kDefaultEnvironmentLightingIntensity = 1.0f;
-  static constexpr float kDefaultDiffuseFallbackIntensity = 0.0f;
-  static constexpr float kDefaultSpecularFallbackIntensity = 0.0f;
+  static constexpr float kDefaultDiffuseFallbackIntensity = 1.0f;
+  static constexpr float kDefaultSpecularFallbackIntensity = 1.0f;
 
   struct IndirectEnvironmentSource {
     IndirectEnvironmentSourceKind kind = IndirectEnvironmentSourceKind::EngineDefault;

--- a/EvoEngine_SDK/include/Rendering/RenderInstances/RenderInstanceStorage.hpp
+++ b/EvoEngine_SDK/include/Rendering/RenderInstances/RenderInstanceStorage.hpp
@@ -286,8 +286,8 @@ class RenderInstanceStorage {
     alignas(4) float environment_pdf_texture_index = -1.0f;          ///< Texture index for the environment CDF/PDF map.
     alignas(4) float environment_cubemap_index = -1.0f;   ///< Cubemap index for ray-traced environment light.
     alignas(4) float environment_rotation = 0.0f;         ///< Y-axis rotation in radians.
-    alignas(4) float diffuse_fallback_intensity = 0.0f;   ///< Effective raster/DDGI diffuse fallback scale.
-    alignas(4) float specular_fallback_intensity = 0.0f;  ///< Effective raster specular fallback scale.
+    alignas(4) float diffuse_fallback_intensity = 1.0f;   ///< Effective raster/DDGI diffuse fallback scale.
+    alignas(4) float specular_fallback_intensity = 1.0f;  ///< Effective raster specular fallback scale.
 
     /**
      * @brief Compares two EnvironmentInfoBlock objects for inequality.

--- a/EvoEngine_SDK/src/Application.cpp
+++ b/EvoEngine_SDK/src/Application.cpp
@@ -2538,13 +2538,13 @@ void Application::Terminate() {
   this->active_scene_.reset();
   TextureStorage::OnDestroy();
   GeometryStorage::OnDestroy();
+  PackageManager::UnloadAll();
 
   if (has_render_layer) {
     Platform::OnDestroy();
   }
 
   Jobs::OnDestroy();
-  PackageManager::UnloadAll();
   Serialization::OnDestroy();
 
   this->execution_status_ = ExecutionStatus::Uninitialized;

--- a/EvoEngine_Tests/Core/EnvironmentalLightingAssetTest.cpp
+++ b/EvoEngine_Tests/Core/EnvironmentalLightingAssetTest.cpp
@@ -490,7 +490,7 @@ TEST(EnvironmentalLightingAsset, ResolverDefaultsUseSceneTemporaryEnvironmentalL
   EXPECT_TRUE(resolved.ddgi_volumes.empty());
 }
 
-TEST(EnvironmentalLightingAsset, ResolverClampsInvalidFallbackIntensitiesToDefaults) {
+TEST(EnvironmentalLightingAsset, ResolverUsesDefaultsForNonFiniteFallbackIntensities) {
   Application app;
   ApplicationContextScope scope(app);
   app.Initialize(EmptyProjectSettings());
@@ -501,7 +501,7 @@ TEST(EnvironmentalLightingAsset, ResolverClampsInvalidFallbackIntensitiesToDefau
   scene->environmental_lighting = lighting;
 
   lighting->environment_lighting_intensity = std::numeric_limits<float>::quiet_NaN();
-  lighting->diffuse_fallback_intensity = -1.0f;
+  lighting->diffuse_fallback_intensity = std::numeric_limits<float>::quiet_NaN();
   lighting->specular_fallback_intensity = std::numeric_limits<float>::infinity();
 
   const auto resolved = ResolveEnvironmentalLighting(scene);

--- a/EvoEngine_Tests/Core/EnvironmentalLightingContractTest.cpp
+++ b/EvoEngine_Tests/Core/EnvironmentalLightingContractTest.cpp
@@ -34,8 +34,8 @@ TEST(EnvironmentalLightingContract, DefaultRuntimeViewEncodesNoAssetFallback) {
   EXPECT_FLOAT_EQ(resolved.specular_fallback_intensity,
                   ResolvedEnvironmentalLighting::kDefaultSpecularFallbackIntensity);
   EXPECT_FLOAT_EQ(ResolvedEnvironmentalLighting::kDefaultEnvironmentLightingIntensity, 1.0f);
-  EXPECT_FLOAT_EQ(ResolvedEnvironmentalLighting::kDefaultDiffuseFallbackIntensity, 0.0f);
-  EXPECT_FLOAT_EQ(ResolvedEnvironmentalLighting::kDefaultSpecularFallbackIntensity, 0.0f);
+  EXPECT_FLOAT_EQ(ResolvedEnvironmentalLighting::kDefaultDiffuseFallbackIntensity, 1.0f);
+  EXPECT_FLOAT_EQ(ResolvedEnvironmentalLighting::kDefaultSpecularFallbackIntensity, 1.0f);
   EXPECT_FALSE(resolved.environmental_lighting_asset_assigned);
   EXPECT_TRUE(resolved.uses_engine_default_indirect_environment_source);
   EXPECT_TRUE(resolved.local_reflection_probes.empty());
@@ -158,8 +158,8 @@ TEST(EnvironmentalLightingContract, DocsAndHeaderCarryLockedFallbackTerminology)
   EXPECT_NE(rendering_docs.find("Surface/volume environment sampling and secondary misses:"), std::string::npos);
   EXPECT_NE(rendering_docs.find("Ray cameras do not use `Scene::global_reflection_probe_fallback`"), std::string::npos);
   EXPECT_NE(rendering_docs.find("Ray cameras ignore `diffuse_fallback_intensity`"), std::string::npos);
-  EXPECT_NE(rendering_docs.find("diffuse_fallback_intensity = 0.0f"), std::string::npos);
-  EXPECT_NE(rendering_docs.find("specular_fallback_intensity = 0.0f"), std::string::npos);
+  EXPECT_NE(rendering_docs.find("diffuse_fallback_intensity = 1.0f"), std::string::npos);
+  EXPECT_NE(rendering_docs.find("specular_fallback_intensity = 1.0f"), std::string::npos);
   EXPECT_NE(rendering_docs.find("fallback contribution still uses the resolved fallback intensity"), std::string::npos);
   EXPECT_NE(rendering_docs.find("DDGI miss radiance is"), std::string::npos);
   EXPECT_NE(rendering_docs.find("Bake environment input uses `environment_lighting_intensity` only"),

--- a/EvoEngine_Tests/Core/GltfRasterMaterialShaderTest.cpp
+++ b/EvoEngine_Tests/Core/GltfRasterMaterialShaderTest.cpp
@@ -116,6 +116,13 @@ TEST(GltfRasterMaterial, EvaluatorCoversCanonicalTextureInfoAndPbrTerms) {
   EXPECT_NE(source.find("return f0 + (f90 - f0) * pow"), std::string::npos);
   EXPECT_NE(source.find("mix(dielectric_specular_f0, max(surface.base_color.rgb"), std::string::npos);
   EXPECT_EQ(source.find("return mix(vec3(0.04)"), std::string::npos);
+  const auto rebase_specular_f0 =
+      ExtractSourceRange(source, "vec3 EE_GLTF_RASTER_REBASE_SPECULAR_F0", "vec3 EE_GLTF_SAFE_NORMALIZE");
+  EXPECT_NE(rebase_specular_f0.find("return surface.specular_f0"), std::string::npos);
+  EXPECT_NE(rebase_specular_f0.find("const float metallic = clamp(surface.metallic"), std::string::npos);
+  EXPECT_NE(rebase_specular_f0.find("surface.specular_f0 - original_base_color * metallic"), std::string::npos);
+  EXPECT_NE(rebase_specular_f0.find("return mix(dielectric_specular_f0, rebased_base_color, metallic)"),
+            std::string::npos);
   EXPECT_NE(source.find("surface.occlusion = 1.0 + surface.occlusion * (occlusion - 1.0)"), std::string::npos);
   EXPECT_NE(source.find("material.normal_texture_scale"), std::string::npos);
   EXPECT_NE(source.find("surface.emissive *="), std::string::npos);
@@ -939,6 +946,86 @@ TEST(GltfRasterMaterial, EcoSysLabDynamicFoliageMeshShadersGuardLeafOutputIndice
     EXPECT_EQ(source.find("triangle_index <= LEAF_TRIANGLE_SIZE"), std::string::npos) << path.string();
     EXPECT_NE(source.find("vertex_index >= LEAF_VERTICES_SIZE"), std::string::npos) << path.string();
     EXPECT_NE(source.find("triangle_index < LEAF_TRIANGLE_SIZE"), std::string::npos) << path.string();
+  }
+}
+
+TEST(GltfRasterMaterial, EcoSysLabSegmentPairsMeshFragmentInterfaceMatches) {
+  const auto task = ReadTextFile(
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Task/DynamicStrands/"
+               "Rendering/SegmentPairs.task"));
+  const auto mesh = ReadTextFile(
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/"
+               "Rendering/SegmentPairs/Rendering.mesh"));
+  const auto fragment = ReadTextFile(
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Fragment/DynamicStrands/"
+               "Rendering/SegmentPairs.frag"));
+  ASSERT_FALSE(task.empty());
+  ASSERT_FALSE(mesh.empty());
+  ASSERT_FALSE(fragment.empty());
+
+  EXPECT_NE(task.find("bool render = segment_pair_index_global < segment_pairs_size"), std::string::npos);
+  EXPECT_EQ(task.find("Segment segment0 = segments[segment_pair.segment0_handle]"), std::string::npos);
+  EXPECT_NE(mesh.find("vec2 tex_coord"), std::string::npos);
+  EXPECT_NE(mesh.find("ms_v_out[vertex_index].tex_coord = vertex_position.xy + vec2(0.5)"), std::string::npos);
+  EXPECT_NE(mesh.find("vertex_index >= segment_pair_VERTICES_SIZE"), std::string::npos);
+  EXPECT_NE(mesh.find("triangle_index < segment_pair_TRIANGLE_SIZE"), std::string::npos);
+  EXPECT_NE(fragment.find("vec2 TexCoord"), std::string::npos);
+  EXPECT_NE(fragment.find("vec4 Color"), std::string::npos);
+
+  const auto visualization_task = ReadTextFile(
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Task/DynamicStrands/"
+               "Visualization/SegmentPairs.task"));
+  const auto visualization_mesh = ReadTextFile(
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/"
+               "Visualization/SegmentPairs.mesh"));
+  ASSERT_FALSE(visualization_task.empty());
+  ASSERT_FALSE(visualization_mesh.empty());
+
+  EXPECT_NE(visualization_task.find("bool render = segment_pair_index_global < segment_pairs_size"), std::string::npos);
+  EXPECT_EQ(visualization_task.find("Segment segment0 = segments[segment_pair.segment0_handle]"), std::string::npos);
+  EXPECT_NE(visualization_mesh.find("vertex_index >= segment_pair_VERTICES_SIZE"), std::string::npos);
+  EXPECT_NE(visualization_mesh.find("triangle_index < segment_pair_TRIANGLE_SIZE"), std::string::npos);
+}
+
+TEST(GltfRasterMaterial, EcoSysLabShadowMeshShadersAvoidUnusedFragmentVaryings) {
+  const std::filesystem::path depth_only_shadow_paths[] = {
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/"
+               "Rendering/Foliage/PointLightShadowMap.mesh"),
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/"
+               "Rendering/Foliage/SpotLightShadowMap.mesh"),
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/"
+               "Rendering/Foliage/DirectionalLightShadowMap.mesh"),
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/"
+               "Rendering/KineticVoronoiMeshing/SegmentMeshlet/PointLightShadowMap.mesh"),
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/"
+               "Rendering/KineticVoronoiMeshing/SegmentMeshlet/SpotLightShadowMap.mesh"),
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/"
+               "Rendering/KineticVoronoiMeshing/SegmentMeshlet/DirectionalLightShadowMap.mesh"),
+  };
+
+  for (const auto& path : depth_only_shadow_paths) {
+    const auto source = ReadTextFile(path);
+    ASSERT_FALSE(source.empty()) << path.string();
+    EXPECT_EQ(source.find("out MS_V_OUT"), std::string::npos) << path.string();
+    EXPECT_EQ(source.find("ms_v_out["), std::string::npos) << path.string();
+  }
+
+  const std::filesystem::path small_segment_shadow_paths[] = {
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/"
+               "Rendering/AlphaShapeMeshing/SmallSegments/PointLightShadowMap.mesh"),
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/"
+               "Rendering/AlphaShapeMeshing/SmallSegments/SpotLightShadowMap.mesh"),
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Graphics/Mesh/DynamicStrands/"
+               "Rendering/AlphaShapeMeshing/SmallSegments/DirectionalLightShadowMap.mesh"),
+  };
+
+  for (const auto& path : small_segment_shadow_paths) {
+    const auto source = ReadTextFile(path);
+    ASSERT_FALSE(source.empty()) << path.string();
+    EXPECT_NE(source.find("vertex_index >= SMALL_SEGMENT_SHADOW_MAP_VERTICES_SIZE"), std::string::npos)
+        << path.string();
+    EXPECT_NE(source.find("triangle_index < SMALL_SEGMENT_SHADOW_MAP_TRIANGLE_SIZE"), std::string::npos)
+        << path.string();
   }
 }
 

--- a/EvoEngine_Tests/Core/ShaderCacheTest.cpp
+++ b/EvoEngine_Tests/Core/ShaderCacheTest.cpp
@@ -13,6 +13,7 @@
 #include <filesystem>
 #include <fstream>
 #include <future>
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <string>
@@ -21,6 +22,16 @@
 using namespace evo_engine;
 
 namespace {
+std::filesystem::path RepoPath(const std::filesystem::path& relative_path) {
+  return std::filesystem::path(EVOENGINE_TEST_SOURCE_DIR) / relative_path;
+}
+
+std::string ReadTextFile(const std::filesystem::path& path) {
+  std::ifstream file(path);
+  EXPECT_TRUE(file.good()) << path.string();
+  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+
 void SetEnvironment(const char* name, const std::string& value) {
 #ifdef _WIN32
   _putenv_s(name, value.c_str());
@@ -75,6 +86,13 @@ class ShaderCacheScope {
 constexpr const char* kComputeShader = R"(
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 void main() {}
+)";
+
+constexpr const char* kComputeShaderGlobalDefines = R"(
+#define SUBGROUP_SIZE 32
+#define COMPUTE_SUBGROUP_COUNT 8
+#define COMPUTE_WORK_GROUP_INVOCATIONS 256
+#define MAX_COMPUTE_WORK_GROUP_INVOCATIONS 1024
 )";
 
 size_t CacheFileCount(const std::filesystem::path& root) {
@@ -164,6 +182,22 @@ TEST(ShaderCache, StageAndSourceChangesCreateDistinctEntries) {
       changed_source));
   EXPECT_EQ(CacheFileCount(scope.Root()), 3u);
   EXPECT_EQ(Shader::GetCompileCacheStats().compilations, 3u);
+}
+
+TEST(ShaderCache, EcoSysLabPackedFungusEdgeShaderCompiles) {
+  ShaderCacheScope scope;
+  Shader::RegisterShaderIncludePath(
+      RepoPath("EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Includes"));
+  Shader::RegisterShaderIncludePath(RepoPath("EvoEngine_SDK/Internals/DefaultResources/Shaders/Includes"));
+
+  const auto shader_path = RepoPath(
+      "EvoEngine_Packages/EcoSysLab/Internals/EcoSysLabResources/Shaders/Compute/DynamicStrands/Fungus/"
+      "FungusDiffusion_edge.comp");
+  const auto source = std::string(kComputeShaderGlobalDefines) + ReadTextFile(shader_path);
+
+  std::vector<uint32_t> binaries;
+  ASSERT_TRUE(Shader::CompileToSpirv(ShaderType::Compute, source, binaries, shader_path));
+  EXPECT_FALSE(binaries.empty());
 }
 
 TEST(ShaderCache, IncludeContentInvalidatesDeterministicKey) {

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -46,8 +46,8 @@ If a requested ray mode is unavailable, the camera falls back to the best suppor
 The renderer resolves `Scene + EnvironmentalLighting` into a `ResolvedEnvironmentalLighting` runtime view. New scenes and
 loaded scenes with an empty `Scene::environmental_lighting` reference create a temporary `EnvironmentalLighting` asset and
 link it to the scene. That default asset resolves to the engine-default indirect environment source with
-`environment_lighting_intensity = 1.0f`, `diffuse_fallback_intensity = 0.0f`, and
-`specular_fallback_intensity = 0.0f`. The resolver still keeps a defensive no-asset default for malformed in-memory state;
+`environment_lighting_intensity = 1.0f`, `diffuse_fallback_intensity = 1.0f`, and
+`specular_fallback_intensity = 1.0f`. The resolver still keeps a defensive no-asset default for malformed in-memory state;
 normal scene creation and loading should not hit it.
 
 Current implementation status: the `EnvironmentalLighting` asset schema, `Scene::environmental_lighting` reference,

--- a/imgui.ini
+++ b/imgui.ini
@@ -1,0 +1,121 @@
+[Window][Scene]
+Pos=0,0
+Size=320,180
+Collapsed=0
+
+[Window][Camera]
+Pos=1749,507
+Size=660,735
+Collapsed=0
+DockId=0x00000008,0
+
+[Window][Plant Visual]
+Collapsed=0
+DockId=0x00000007
+
+[Window][Entity Explorer]
+Pos=0,57
+Size=287,123
+Collapsed=0
+DockId=0x00000001,0
+
+[Window][Entity Inspector]
+Pos=304,57
+Size=16,123
+Collapsed=0
+DockId=0x00000004,0
+
+[Window][Render Layer]
+Collapsed=0
+DockId=0x00000001
+
+[Window][Editor Layer]
+Collapsed=0
+DockId=0x00000001
+
+[Window][Project]
+Pos=288,90
+Size=15,90
+Collapsed=0
+DockId=0x00000006,1
+
+[Window][Console]
+Pos=288,90
+Size=15,90
+Collapsed=0
+DockId=0x00000006,0
+
+[Window][Resources]
+Collapsed=0
+
+[Window][Runtime Package Manager]
+Pos=1296,526
+Size=600,530
+Collapsed=0
+
+[Window][Root DockSpace]
+Pos=0,57
+Size=320,123
+Collapsed=0
+
+[Window][Debug##Default]
+ViewportPos=1180,666
+ViewportId=0x16723995
+Size=400,400
+Collapsed=0
+
+[Window][AssetInspector_3955165707122750230]
+Pos=24,526
+Size=292,530
+Collapsed=0
+
+[Window][AssetInspector_7433597773694205082]
+Pos=24,526
+Size=292,530
+Collapsed=0
+
+[Window][AssetInspector_6181562310843636057]
+Pos=24,526
+Size=292,530
+Collapsed=0
+
+[Window][AssetInspector_14495437881421288468]
+Pos=24,526
+Size=292,530
+Collapsed=0
+
+[Window][AssetInspector_7890947038592730525]
+Pos=24,526
+Size=292,530
+Collapsed=0
+
+[Window][AssetInspector_8154489818570821396]
+Pos=24,526
+Size=292,530
+Collapsed=0
+
+[Window][AssetInspector_3935576422154654882]
+Pos=24,526
+Size=292,530
+Collapsed=0
+
+[Window][AssetInspector_8198306988387520446]
+Pos=24,526
+Size=292,530
+Collapsed=0
+
+[Window][AssetInspector_5679062618753974307]
+Pos=24,526
+Size=292,530
+Collapsed=0
+
+[Docking][Data]
+DockSpace         ID=0xC67D619F Window=0xCF30BAD2 Pos=1120,663 Size=320,123 Split=X
+  DockNode        ID=0x00000001 Parent=0xC67D619F SizeRef=287,1023 Selected=0x75612EB8
+  DockNode        ID=0x00000002 Parent=0xC67D619F SizeRef=1632,1023 Split=X
+    DockNode      ID=0x00000003 Parent=0x00000002 SizeRef=1321,1023 Split=Y
+      DockNode    ID=0x00000005 Parent=0x00000003 SizeRef=1321,735 Split=X
+        DockNode  ID=0x00000007 Parent=0x00000005 SizeRef=660,735 CentralNode=1 Selected=0xE601B12F
+        DockNode  ID=0x00000008 Parent=0x00000005 SizeRef=660,735 Selected=0xAA49D574
+      DockNode    ID=0x00000006 Parent=0x00000003 SizeRef=1321,287 Selected=0x9C21DE82
+    DockNode      ID=0x00000004 Parent=0x00000002 SizeRef=310,1023 Selected=0x82A01C92


### PR DESCRIPTION
## Summary
- seed the GLSL-to-Slang migration branch with the editor-layer local edits
- fix EcoSysLab dynamic-strand shader validation paths: packed fungus push constants, SegmentPairs interfaces, shadow mesh outputs, descriptor validity, and package GPU-resource teardown
- update environmental lighting diffuse/specular fallback defaults to 1.0 and refresh the docs/tests that lock the contract

## Validation
- `git diff --check`
- `git diff --cached --check`
- `MSBuild.exe .\EvoEngine_Tests\EvoEngine_Tests.vcxproj /p:Configuration=RelWithDebInfo /p:Platform=x64 /m:1 /nr:false /v:minimal`
- `EvoEngine_Tests.exe --gtest_filter=GltfRasterMaterial.*:ShaderCache.EcoSysLabPackedFungusEdgeShaderCompiles`
- `EvoEngine_Tests.exe --gtest_filter=EnvironmentalLightingContract.*:EnvironmentalLightingAsset.SceneCreatesAndEmbedsTemporaryEnvironmentalLightingWhenMissing:EnvironmentalLightingAsset.ResolverDefaultsUseSceneTemporaryEnvironmentalLightingAsset:EnvironmentalLightingAsset.ResolverUsesDefaultsForNonFiniteFallbackIntensities`
- `cmake --build --preset install-vs2026-x64-RelWithDebInfo --parallel`